### PR TITLE
Layer Lock

### DIFF
--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -388,6 +388,22 @@ class AppActions(NxtActionContainer):
         self.clear_logs_action.setShortcutContext(context)
         self.available_without_model.append(self.clear_logs_action)
 
+        # Toggle error ding sound
+        def toggle_ding():
+            pref_key = user_dir.USER_PREF.DING
+            ding_state = self.toggle_ding_action.isChecked()
+            user_dir.user_prefs[pref_key] = ding_state
+
+        self.toggle_ding_action = NxtAction('Error sound', parent=self)
+        self.toggle_ding_action.setWhatsThis('When enabled a "ding" sound will be played when NXT is given bad input '
+                                             'or encounters and error')
+        self.toggle_ding_action.setCheckable(True)
+        _ding_state = user_dir.user_prefs.get(user_dir.USER_PREF.DING, True)
+        self.toggle_ding_action.setChecked(_ding_state)
+        self.toggle_ding_action.triggered.connect(toggle_ding)
+        self.toggle_ding_action.setShortcutContext(context)
+        self.available_without_model.append(self.toggle_ding_action)
+
         self.action_display_order = [self.find_node_action,
                                      self.new_graph_action,
                                      self.open_file_action, self.undo_action,
@@ -400,6 +416,7 @@ class AppActions(NxtActionContainer):
                                      self.output_log_action,
                                      self.hotkey_editor_action,
                                      self.workflow_tools_action,
+                                     self.toggle_ding_action,
                                      self.clear_logs_action,
                                      self.close_action]
 

--- a/nxt_editor/commands.py
+++ b/nxt_editor/commands.py
@@ -1672,7 +1672,7 @@ class SetLayerLock(NxtCommand):
             layer.lock = self.old_lock
         else:
             layer.set_locked_over(self.old_lock)
-        self.remove_effected_layer(self.model.top_layer.real_path)
+        self.undo_effected_layer(self.model.top_layer.real_path)
         self.model.layer_lock_changed.emit(self.layer_path)
 
     @processing
@@ -1684,7 +1684,7 @@ class SetLayerLock(NxtCommand):
         else:
             self.old_lock = layer.get_locked(fallback_to_local=False)
             layer.set_locked_over(self.lock)
-        self.add_effected_layer(self.model.top_layer.real_path)
+        self.redo_effected_layer(self.model.top_layer.real_path)
         self.model.layer_lock_changed.emit(self.layer_path)
         self.setText("Set {} lock to {}".format(layer.filepath, self.lock))
 

--- a/nxt_editor/dockwidgets/code_editor.py
+++ b/nxt_editor/dockwidgets/code_editor.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(nxt_editor.LOGGER_NAME)
 class CodeEditor(DockWidgetBase):
 
     def __init__(self, title='Code Editor', parent=None, minimum_width=500):
-        super(CodeEditor, self).__init__(title=title, parent=parent, minimum_width=minimum_width)
+        super(CodeEditor, self).__init__(title=title, parent=parent,
+                                         minimum_width=minimum_width)
         self.setObjectName('Code Editor')
         self.main_window = parent
         self.ce_actions = self.main_window.code_editor_actions
@@ -32,6 +33,7 @@ class CodeEditor(DockWidgetBase):
         # local attributes
         self.editing_active = False
         self.code_is_local = False
+        self.locked = False
         self.node_path = None
         self.node_name = ''
         self.actual_display_state = ''
@@ -187,15 +189,15 @@ class CodeEditor(DockWidgetBase):
                                       QtCore.Qt.AlignRight)
 
         # remove code button
-        self.remove_code_button = PixmapButton(pixmap=':icons/icons/delete.png',
-                                                  pixmap_hover=':icons/icons/delete_hover.png',
-                                                  pixmap_pressed=':icons/icons/delete_pressed.png',
-                                                  size=12,
-                                                  parent=self.code_frame)
-        self.remove_code_button.setToolTip('Remove Compute')
-        self.remove_code_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
-        self.remove_code_button.clicked.connect(self.revert_code)
-        self.buttons_layout.addWidget(self.remove_code_button, 0, 7,
+        self.revert_code_button = PixmapButton(pixmap=':icons/icons/delete.png',
+                                               pixmap_hover=':icons/icons/delete_hover.png',
+                                               pixmap_pressed=':icons/icons/delete_pressed.png',
+                                               size=12,
+                                               parent=self.code_frame)
+        self.revert_code_button.setToolTip('Remove Compute')
+        self.revert_code_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
+        self.revert_code_button.clicked.connect(self.revert_code)
+        self.buttons_layout.addWidget(self.revert_code_button, 0, 7,
                                       QtCore.Qt.AlignRight)
         if not self.main_window.in_startup:
             # default state
@@ -230,6 +232,7 @@ class CodeEditor(DockWidgetBase):
         self.model_signal_connections = [
             (model.node_focus_changed, self.accept_edit),
             (model.node_focus_changed, self.set_represented_node),
+            (model.layer_lock_changed, self.handle_lock_changed),
             (model.nodes_changed, self.update_editor),
             (model.attrs_changed, self.update_editor),
             (model.data_state_changed, self.update_editor),
@@ -246,6 +249,19 @@ class CodeEditor(DockWidgetBase):
         self.editor.clearFocus()
         self.editor.hide()
         self.update_background()
+
+    def handle_lock_changed(self, *args):
+        self.locked = self.stage_model.get_node_locked(self.node_path)
+        self.name_label.setReadOnly(self.locked)
+        # Enable/Disable
+        self.accept_button.setEnabled(not self.locked)
+        self.cancel_button.setEnabled(not self.locked)
+        self.revert_code_button.setEnabled(not self.locked)
+        keep_active = [self.ce_actions.copy_resolved_action]
+        for action in self.ce_actions.actions() + self.exec_actions.actions():
+            if action in keep_active:
+                continue
+            action.setEnabled(not self.locked)
 
     def set_represented_node(self):
         self.node_path = self.stage_model.node_focus
@@ -265,6 +281,7 @@ class CodeEditor(DockWidgetBase):
 
         self.display_editor()
         self.display_details()
+        self.handle_lock_changed()
 
     def copy_resolved(self):
         if not self.stage_model:
@@ -429,7 +446,7 @@ class CodeEditor(DockWidgetBase):
 
     def enter_editing(self):
         # prevent re-activating when the mouse is clicked inside the editor
-        if self.editing_active:
+        if self.editing_active or self.locked:
             return
         self.cached_code = self.editor.toPlainText()
         self.cached_code_lines = self.cached_code.split('\n')

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -52,6 +52,7 @@ class PropertyEditor(DockWidgetBase):
         self.stage_model = graph_model
         self.node_path = None
         self._resolved = True
+        self.locked = False
         self.node_path = ''
         self.node_instance = ''
         self.node_inst_source = ('', '')
@@ -204,15 +205,15 @@ class PropertyEditor(DockWidgetBase):
         self.instance_layout.addWidget(self.locate_instance_button, 0, 1)
         self.instance_opinions = OpinionDots(self, 'Instance Opinions')
         self.instance_layout.addWidget(self.instance_opinions, 0, 2)
-        self.remove_instance_button = PixmapButton(pixmap=':icons/icons/delete.png',
+        self.revert_instance_button = PixmapButton(pixmap=':icons/icons/delete.png',
                                                    pixmap_hover=':icons/icons/delete_hover.png',
                                                    pixmap_pressed=':icons/icons/delete_pressed.png',
                                                    size=12,
                                                    parent=self.properties_frame)
-        self.remove_instance_button.setToolTip('Revert Instance')
-        self.remove_instance_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
-        self.remove_instance_button.set_action(self.revert_inst_path_action)
-        self.instance_layout.addWidget(self.remove_instance_button, 0, 3)
+        self.revert_instance_button.setToolTip('Revert Instance')
+        self.revert_instance_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
+        self.revert_instance_button.set_action(self.revert_inst_path_action)
+        self.instance_layout.addWidget(self.revert_instance_button, 0, 3)
 
         # execute in
         self.execute_label = QtWidgets.QLabel('Exec Input', parent=self)
@@ -237,15 +238,15 @@ class PropertyEditor(DockWidgetBase):
         self.execute_field.setCompleter(self.execute_field_completer)
         self.execute_opinions = OpinionDots(self, 'Execute Opinions')
         self.execute_layout.addWidget(self.execute_opinions, 0, 1)
-        self.remove_exec_source_button = PixmapButton(pixmap=':icons/icons/delete.png',
+        self.revert_exec_source_button = PixmapButton(pixmap=':icons/icons/delete.png',
                                                       pixmap_hover=':icons/icons/delete_hover.png',
                                                       pixmap_pressed=':icons/icons/delete_pressed.png',
                                                       size=12,
                                                       parent=self.properties_frame)
-        self.remove_exec_source_button.setToolTip('Revert Execute Source')
-        self.remove_exec_source_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
-        self.remove_exec_source_button.set_action(self.revert_exec_path_action)
-        self.execute_layout.addWidget(self.remove_exec_source_button, 0, 2)
+        self.revert_exec_source_button.setToolTip('Revert Execute Source')
+        self.revert_exec_source_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
+        self.revert_exec_source_button.set_action(self.revert_exec_path_action)
+        self.execute_layout.addWidget(self.revert_exec_source_button, 0, 2)
         # execute_order
         self.child_order_label = QtWidgets.QLabel('Child Order',
                                                   parent=self)
@@ -321,17 +322,17 @@ class PropertyEditor(DockWidgetBase):
         self.position_layout.addWidget(self.enabled_opinions, 0,
                                        QtCore.Qt.AlignLeft)
         icn = ':icons/icons/'
-        self.revert_enabled = PixmapButton(pixmap=icn+'delete.png',
-                                           pixmap_hover=icn+'delete_hover.png',
-                                           pixmap_pressed=icn+'delete_pressed.png',
-                                           size=12,
-                                           parent=self.properties_frame)
-        self.revert_enabled.setToolTip('Revert Enabled State')
-        self.revert_enabled.setStyleSheet('QToolTip {color: white; '
+        self.revert_enabled_button = PixmapButton(pixmap=icn + 'delete.png',
+                                                  pixmap_hover=icn+'delete_hover.png',
+                                                  pixmap_pressed=icn+'delete_pressed.png',
+                                                  size=12,
+                                                  parent=self.properties_frame)
+        self.revert_enabled_button.setToolTip('Revert Enabled State')
+        self.revert_enabled_button.setStyleSheet('QToolTip {color: white; '
                                           'order: 1px solid #3E3E3E'
                                           '}')
-        self.revert_enabled.clicked.connect(self.revert_node_enabled)
-        self.position_layout.addWidget(self.revert_enabled, 0,
+        self.revert_enabled_button.clicked.connect(self.revert_node_enabled)
+        self.position_layout.addWidget(self.revert_enabled_button, 0,
                                        QtCore.Qt.AlignLeft)
 
         self.position_layout.addStretch()
@@ -352,15 +353,15 @@ class PropertyEditor(DockWidgetBase):
         self.comment_layout.addWidget(self.comment_field, 0, 0)
         self.comment_opinions = OpinionDots(self, 'Comment Opinions', vertical=True)
         self.comment_layout.addWidget(self.comment_opinions, 0, 1)
-        self.remove_comment_button = PixmapButton(pixmap=':icons/icons/delete.png',
+        self.revert_comment_button = PixmapButton(pixmap=':icons/icons/delete.png',
                                                   pixmap_hover=':icons/icons/delete_hover.png',
                                                   pixmap_pressed=':icons/icons/delete_pressed.png',
                                                   size=12,
                                                   parent=self.properties_frame)
-        self.remove_comment_button.setToolTip('Revert Comment')
-        self.remove_comment_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
-        self.remove_comment_button.clicked.connect(self.remove_comment)
-        self.comment_layout.addWidget(self.remove_comment_button, 0, 2)
+        self.revert_comment_button.setToolTip('Revert Comment')
+        self.revert_comment_button.setStyleSheet('QToolTip {color: white; border: 1px solid #3E3E3E}')
+        self.revert_comment_button.clicked.connect(self.remove_comment)
+        self.comment_layout.addWidget(self.revert_comment_button, 0, 2)
         # Comment
         self.accept_comment_action = self.comment_actions.accept_comment_action
         self.accept_comment_action.triggered.connect(self.accept_edit_comment)
@@ -510,6 +511,7 @@ class PropertyEditor(DockWidgetBase):
     def set_stage_model_connections(self, model, connect):
         self.model_signal_connections = [
             (model.node_focus_changed, self.set_represented_node),
+            (model.layer_lock_changed, self.handle_locking),
             (model.nodes_changed, self.handle_nodes_changed),
             (model.attrs_changed, self.handle_attrs_changed),
             (model.data_state_changed, self.update_resolved),
@@ -523,6 +525,33 @@ class PropertyEditor(DockWidgetBase):
     def on_stage_model_destroyed(self):
         super(PropertyEditor, self).on_stage_model_destroyed()
         self.properties_frame.hide()
+
+    def handle_locking(self, *args):
+        self.locked = self.stage_model.get_node_locked(self.node_path)
+        if self.locked:
+            self.table_view.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        else:
+            self.table_view.setEditTriggers(QtWidgets.QAbstractItemView.DoubleClicked)
+        # Read only
+        self.name_label.setReadOnly(self.locked)
+        self.instance_field.setReadOnly(self.locked)
+        self.execute_field.setReadOnly(self.locked)
+        self.child_order_field.setReadOnly(self.locked)
+        self.positionX_field.setReadOnly(self.locked)
+        self.positionY_field.setReadOnly(self.locked)
+        self.comment_field.setReadOnly(self.locked)
+        # Enable/Disable
+        self.revert_instance_button.setEnabled(not self.locked)
+        self.revert_exec_source_button.setEnabled(not self.locked)
+        self.revert_child_order_button.setEnabled(not self.locked)
+        self.enabled_checkbox.setEnabled(not self.locked)
+        self.revert_enabled_button.setEnabled(not self.locked)
+        self.revert_comment_button.setEnabled(not self.locked)
+        self.add_attr_button.setEnabled(not self.locked)
+        self.remove_attr_button.setEnabled(not self.locked)
+        # Actions
+        for action in self.authoring_actions.actions() + self._actions.actions() + self.comment_actions.actions():
+            action.setEnabled(not self.locked)
 
     def handle_nodes_changed(self, nodes):
         if self.node_path in nodes:
@@ -625,6 +654,7 @@ class PropertyEditor(DockWidgetBase):
 
         # update attribute model
         self.model.set_represented_node(node_path=self.node_path)
+        self.handle_locking()
 
     def view_instance_node(self):
         instance_path = self.instance_field.text()
@@ -653,6 +683,10 @@ class PropertyEditor(DockWidgetBase):
                                                                 expand=expand)
             if comp_path != path:
                 path = comp_path
+        if in_focus:
+            self.instance_field.focus_in_val = path
+        else:
+            self.instance_field.focus_in_val = ''
         self.instance_field.setText(path)
 
     def update_properties(self):
@@ -774,12 +808,12 @@ class PropertyEditor(DockWidgetBase):
             self.instance_label.setVisible(not is_world)
             self.instance_field.setVisible(not is_world)
             self.locate_instance_button.setVisible(not is_world)
-            self.remove_instance_button.setVisible(not is_world)
+            self.revert_instance_button.setVisible(not is_world)
             self.instance_opinions.setVisible(not is_world)
 
             self.execute_field.setVisible(is_top)
             self.execute_label.setVisible(is_top)
-            self.remove_exec_source_button.setVisible(is_top)
+            self.revert_exec_source_button.setVisible(is_top)
             self.execute_opinions.setVisible(not is_world)
 
 
@@ -794,7 +828,7 @@ class PropertyEditor(DockWidgetBase):
 
             self.enabled_checkbox.setVisible(not is_world)
             self.enabled_checkbox_label.setVisible(not is_world)
-            self.revert_enabled.setVisible(not is_world)
+            self.revert_enabled_button.setVisible(not is_world)
             self.enabled_opinions.setVisible(not is_world)
 
     def edit_name(self, new_name):
@@ -815,6 +849,7 @@ class PropertyEditor(DockWidgetBase):
         cur_inst_path = self.stage_model.get_node_instance_path(self.node_path,
                                                                 lookup_layer,
                                                                 expand=False)
+        cur_inst_path = str(self.instance_field.focus_in_val)
         instance_path = str(self.instance_field.text())
         if (not cur_inst_path and not instance_path
                 or cur_inst_path == instance_path):
@@ -880,6 +915,8 @@ class PropertyEditor(DockWidgetBase):
             self.stage_model.revert_node_enabled(self.node_path)
 
     def edit_position(self):
+        if self.locked:
+            return
         x = self.positionX_field.value()
         y = self.positionY_field.value()
         if not self.node_path or not self.stage_model.node_exists(self.node_path, self.stage_model.comp_layer):
@@ -1026,8 +1063,9 @@ class PropertyEditor(DockWidgetBase):
                                          self.stage_model)
         menu.popup(QtGui.QCursor.pos())
 
-    @staticmethod
-    def reset_action_enabled(actions):
+    def reset_action_enabled(self, actions):
+        if self.locked:
+            return
         for action in actions:
             action.setEnabled(True)
 
@@ -1061,12 +1099,13 @@ class PropertyEditor(DockWidgetBase):
                                                                 INTERNAL_ATTRS.EXECUTE_IN,
                                                                 self.stage_model.comp_layer)
         tgt_path = self.stage_model.target_layer.real_path
-        if src_path == self.node_path and layer == tgt_path:
-            self.localize_exec_path_action.setEnabled(False)
-            self.revert_exec_path_action.setEnabled(True)
-        else:
-            self.localize_exec_path_action.setEnabled(True)
-            self.revert_exec_path_action.setEnabled(False)
+        if not self.locked:
+            if src_path == self.node_path and layer == tgt_path:
+                self.localize_exec_path_action.setEnabled(False)
+                self.revert_exec_path_action.setEnabled(True)
+            else:
+                self.localize_exec_path_action.setEnabled(True)
+                self.revert_exec_path_action.setEnabled(False)
         link_to = HistoricalContextMenu.LINKS.SOURCE
         historical_menu = HistoricalContextMenu(self, self.node_path,
                                                 INTERNAL_ATTRS.EXECUTE_IN,
@@ -1449,6 +1488,7 @@ class PropertyModel(QtCore.QAbstractTableModel):
 class AttrsTableView(QtWidgets.QTableView):
     def __init__(self, parent=None):
         super(AttrsTableView, self).__init__(parent=parent)
+        # self._parent = parent
         self.node_path_delegate = NodePathBtnDelegate(self)
         self.setItemDelegateForColumn(COLUMNS.source, self.node_path_delegate)
         self.mouse_pressed = False
@@ -1458,6 +1498,8 @@ class AttrsTableView(QtWidgets.QTableView):
         self.installEventFilter(self)
 
     def mousePressEvent(self, event):
+        # if self._parent.stage_model.get_node_locked(self._parent.node_path):
+        #     return
         super(AttrsTableView, self).mousePressEvent(event)
         self.mouse_pressed = self.indexAt(event.pos())
         self.startDrag(event)
@@ -1686,6 +1728,7 @@ class LineEdit(QtWidgets.QLineEdit):
     def __init__(self, parent=None):
         # Cheat because hasFocus is the parent not the actual line
         self.has_focus = False
+        self.focus_in_val = ''
         super(LineEdit, self).__init__(parent)
 
     def keyPressEvent(self, event):

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -1099,13 +1099,9 @@ class PropertyEditor(DockWidgetBase):
                                                                 INTERNAL_ATTRS.EXECUTE_IN,
                                                                 self.stage_model.comp_layer)
         tgt_path = self.stage_model.target_layer.real_path
-        if not self.locked:
-            if src_path == self.node_path and layer == tgt_path:
-                self.localize_exec_path_action.setEnabled(False)
-                self.revert_exec_path_action.setEnabled(True)
-            else:
-                self.localize_exec_path_action.setEnabled(True)
-                self.revert_exec_path_action.setEnabled(False)
+        exec_is_path_local = (src_path == self.node_path) and (layer == tgt_path)
+        self.localize_exec_path_action.setEnabled(not exec_is_path_local and not self.locked)
+        self.revert_exec_path_action.setEnabled(exec_is_path_local and not self.locked)
         link_to = HistoricalContextMenu.LINKS.SOURCE
         historical_menu = HistoricalContextMenu(self, self.node_path,
                                                 INTERNAL_ATTRS.EXECUTE_IN,
@@ -1488,7 +1484,6 @@ class PropertyModel(QtCore.QAbstractTableModel):
 class AttrsTableView(QtWidgets.QTableView):
     def __init__(self, parent=None):
         super(AttrsTableView, self).__init__(parent=parent)
-        # self._parent = parent
         self.node_path_delegate = NodePathBtnDelegate(self)
         self.setItemDelegateForColumn(COLUMNS.source, self.node_path_delegate)
         self.mouse_pressed = False
@@ -1498,8 +1493,6 @@ class AttrsTableView(QtWidgets.QTableView):
         self.installEventFilter(self)
 
     def mousePressEvent(self, event):
-        # if self._parent.stage_model.get_node_locked(self._parent.node_path):
-        #     return
         super(AttrsTableView, self).mousePressEvent(event)
         self.mouse_pressed = self.indexAt(event.pos())
         self.startDrag(event)

--- a/nxt_editor/label_edit.py
+++ b/nxt_editor/label_edit.py
@@ -11,12 +11,21 @@ class LabelEdit(QtWidgets.QLabel):
     def __init__(self, *args, **kwargs):
         super(LabelEdit, self).__init__(*args, **kwargs)
         self.doubleClicked.connect(self.edit_text)
+        self._read_only = False
+
+    def setReadOnly(self, state):
+        """Named this way to mimic Qt"""
+        self._read_only = state
 
     def mouseDoubleClickEvent(self, event):
+        if self._read_only:
+            return
         if event.button() == QtCore.Qt.LeftButton:
             self.doubleClicked.emit()
 
     def edit_text(self):
+        if self._read_only:
+            return
         # get current name
         name = self.text()
 

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -480,8 +480,10 @@ class MainWindow(QtWidgets.QMainWindow):
             self.update()  # TODO: Make this better
         self.set_waiting_cursor(False)
 
-    def ding(self):
-        QtWidgets.QApplication.instance().beep()
+    @staticmethod
+    def ding():
+        if user_dir.user_prefs.get(user_dir.USER_PREF.DING, True):
+            QtWidgets.QApplication.instance().beep()
 
     def center_view(self):
         target_graph_view = self.get_current_view()
@@ -1015,13 +1017,13 @@ class MenuBar(QtWidgets.QMenuBar):
     def __init__(self, parent=None):
         super(MenuBar, self).__init__(parent=parent)
         self.main_window = parent
-        self.app_actions = parent.app_actions
-        self.exec_actions = parent.execute_actions
-        self.node_actions = parent.node_actions
-        self.ce_actions = parent.code_editor_actions
-        self.display_actions = parent.display_actions
-        self.view_actions = parent.view_actions
-        self.layer_actions = parent.layer_actions
+        self.app_actions = parent.app_actions  # type: actions.AppActions
+        self.exec_actions = parent.execute_actions  # type: actions.ExecuteActions
+        self.node_actions = parent.node_actions  # type: actions.NodeActions
+        self.ce_actions = parent.code_editor_actions  # type: actions.CodeEditorActions
+        self.display_actions = parent.display_actions  # type: actions.DisplayActions
+        self.view_actions = parent.view_actions  # type: actions.StageViewActions
+        self.layer_actions = parent.layer_actions  # type: actions.LayerActions
         # File Menu
         self.file_menu = self.addMenu('File')
         self.file_menu.setTearOffEnabled(True)
@@ -1145,6 +1147,11 @@ class MenuBar(QtWidgets.QMenuBar):
         self.remote_menu.addSeparator()
         self.remote_menu.addAction(self.exec_actions.startup_rpc_action)
         self.remote_menu.addAction(self.exec_actions.shutdown_rpc_action)
+        self.options_menu = self.addMenu('Options')
+        self.options_menu.addAction(self.app_actions.toggle_ding_action)
+        self.options_view_sub = self.options_menu.addMenu('View')
+        self.options_view_sub.setTearOffEnabled(True)
+        self.options_view_sub.addActions(self.view_opt_menu.actions())
         # Help Menu
         self.help_menu = self.addMenu('Help')
         self.help_menu.setTearOffEnabled(True)

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -460,6 +460,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # create model
         model = StageModel(stage=stage)
         model.processing.connect(self.set_waiting_cursor)
+        model.request_ding.connect(self.ding)
         model.layer_alias_changed.connect(partial(self.update_tab_title, model))
         # create view
         view = StageView(model=model, parent=self)
@@ -478,6 +479,9 @@ class MainWindow(QtWidgets.QMainWindow):
             self.update_grid_action()
             self.update()  # TODO: Make this better
         self.set_waiting_cursor(False)
+
+    def ding(self):
+        QtWidgets.QApplication.instance().beep()
 
     def center_view(self):
         target_graph_view = self.get_current_view()

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -694,8 +694,6 @@ class NodeGraphicsItem(graphic_type):
     def hoverEnterEvent(self, event):
         """Override of QtWidgets.QGraphicsItem hoverEnterEvent."""
         self.is_hovered = True
-        if self.locked:
-            QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.WhatsThisCursor)
         if self.view.view_actions.tooltip_action.isChecked():
             self.setToolTip(self.get_node_tool_tip())
         else:
@@ -704,7 +702,6 @@ class NodeGraphicsItem(graphic_type):
 
     def hoverLeaveEvent(self, event):
         """Override of QtWidgets.QGraphicsItem hoverLeaveEvent."""
-        QtWidgets.QApplication.restoreOverrideCursor()
         self.is_hovered = False
         self.update()
         super(NodeGraphicsItem, self).hoverLeaveEvent(event)

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -42,6 +42,8 @@ class NodeGraphicsItem(graphic_type):
 
     ATTR_PLUG_RADIUS = 4
     EXEC_PLUG_RADIUS = 6
+    ROUND_X = 2.
+    ROUND_Y = 2.
 
     def __init__(self, model, node_path, view):
         super(NodeGraphicsItem, self).__init__()
@@ -78,6 +80,7 @@ class NodeGraphicsItem(graphic_type):
         self.is_start = False
         self.start_color = colors.ERROR
         self.is_proxy = False
+        self.locked = False
         self.is_real = True
         self.attr_dots = [False, False, False]
         self.error_list = []
@@ -294,6 +297,13 @@ class NodeGraphicsItem(graphic_type):
         self.draw_title(painter, lod)
         self.draw_attributes(painter, lod)
         self.draw_border(painter, lod)
+        if self.locked:
+            self.setFlags(QtWidgets.QGraphicsItem.ItemSendsScenePositionChanges)
+        else:
+            self.setFlags(QtWidgets.QGraphicsItem.ItemIsMovable |
+                          QtWidgets.QGraphicsItem.ItemIsFocusable |
+                          QtWidgets.QGraphicsItem.ItemIsSelectable |
+                          QtWidgets.QGraphicsItem.ItemSendsScenePositionChanges)
 
     def closest_grid_point(self, position):
         snapped_pos = self.model.snap_pos_to_grid((position.x(), position.y()))
@@ -315,17 +325,24 @@ class NodeGraphicsItem(graphic_type):
         else:
             painter.setPen(QtCore.Qt.NoPen)
             return
-            color = self.colors[-1].darker(self.dim_factor)
         if self.is_proxy:
             pen = QtGui.QPen(color, 1, QtCore.Qt.PenStyle.DashLine)
         else:
             pen = QtGui.QPen(color)
-        painter.setPen(pen)
-        painter.setBrush(QtCore.Qt.NoBrush)
-        painter.drawRect(QtCore.QRectF(self.get_selection_rect().x() + 1,
-                         self.get_selection_rect().y() + 1,
-                         self.get_selection_rect().width() - 2,
-                         self.get_selection_rect().height() - 2))
+        if self.locked:
+            c = QtGui.QColor(self.colors[-1])
+            c.setAlphaF(.3)
+            b = QtGui.QBrush(c)
+            painter.setBrush(b)
+            painter.setPen(QtCore.Qt.NoPen)
+        else:
+            painter.setPen(pen)
+            painter.setBrush(QtCore.Qt.NoBrush)
+        rect = QtCore.QRectF(self.get_selection_rect().x() + 1,
+                             self.get_selection_rect().y() + 1,
+                             self.get_selection_rect().width() - 2,
+                             self.get_selection_rect().height() - 2)
+        painter.drawRoundedRect(rect, self.ROUND_X, self.ROUND_Y)
 
     def draw_title(self, painter, lod=1.):
         """Draw title of the node. Called exclusively in paint.
@@ -341,7 +358,7 @@ class NodeGraphicsItem(graphic_type):
             self.scene().removeItem(self.error_item)
             self.error_item.deleteLater()
         self.error_item = None
-        if self.is_real:
+        if self.is_real and not self.locked:
             painter.setBackgroundMode(QtCore.Qt.OpaqueMode)
         else:
             painter.setBackgroundMode(QtCore.Qt.TransparentMode)
@@ -354,19 +371,26 @@ class NodeGraphicsItem(graphic_type):
                 painter.setBackground(color.darker(self.dim_factor))
                 brush = QtGui.QBrush(color.darker(self.dim_factor*2),
                                      QtCore.Qt.FDiagPattern)
-                painter.setBrush(brush)
             else:
-                painter.setBrush(color.darker(self.dim_factor))
+                brush = QtGui.QBrush(color.darker(self.dim_factor))
+            if self.locked:
+                c = color.darker(self.dim_factor)
+                c.setAlphaF(.5)
+                painter.setBackground(c)
+                brush = QtGui.QBrush(c.darker(self.dim_factor * 2),
+                                     QtCore.Qt.Dense1Pattern)
+            painter.setBrush(brush)
             # Top Opinion
             if i+1 == color_count:
                 remaining_width = self.max_width - (i*color_band_width)
-                painter.drawRect(0, 0, remaining_width,
-                                 self.title_rect_height)
+                rect = QtCore.QRectF(0, 0, remaining_width,
+                                     self.title_rect_height)
             # Lower Opinions
             else:
                 x_pos = self.max_width - (i+1)*color_band_width
-                painter.drawRect(x_pos, 0, color_band_width,
-                                 self.title_rect_height)
+                rect = QtCore.QRectF(x_pos, 0, color_band_width,
+                                     self.title_rect_height)
+            painter.drawRoundedRect(rect, self.ROUND_X, self.ROUND_Y)
         painter.setBackground(bg)
         painter.setBackgroundMode(bgm)
         # draw exec plugs
@@ -670,6 +694,8 @@ class NodeGraphicsItem(graphic_type):
     def hoverEnterEvent(self, event):
         """Override of QtWidgets.QGraphicsItem hoverEnterEvent."""
         self.is_hovered = True
+        if self.locked:
+            QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.WhatsThisCursor)
         if self.view.view_actions.tooltip_action.isChecked():
             self.setToolTip(self.get_node_tool_tip())
         else:
@@ -678,6 +704,7 @@ class NodeGraphicsItem(graphic_type):
 
     def hoverLeaveEvent(self, event):
         """Override of QtWidgets.QGraphicsItem hoverLeaveEvent."""
+        QtWidgets.QApplication.restoreOverrideCursor()
         self.is_hovered = False
         self.update()
         super(NodeGraphicsItem, self).hoverLeaveEvent(event)
@@ -703,6 +730,7 @@ class NodeGraphicsItem(graphic_type):
             self.setPos(pos[0], pos[1])
         self.is_real = self.model.node_exists(node_path)
         self.is_proxy = self.model.get_node_is_proxy(node_path)
+        self.locked = self.model.get_node_locked(node_path)
         self.collapse_state = self.model.get_node_collapse(self.node_path,
                                                            comp)
         self.node_enabled = self.model.get_node_enabled(self.node_path)
@@ -1041,6 +1069,9 @@ class NodeGraphicsPlug(QtWidgets.QGraphicsItem):
         # break attribute connections
         if event.modifiers() == QtCore.Qt.AltModifier:
             raise NotImplementedError("Alt to clear attribute is broken.")
+        if self.parentItem().locked:
+            event.accept()
+            return
         if self.attr_name_represented:
             node_path = self.parentItem().node_path
             path = nxt_path.make_attr_path(node_path, self.attr_name_represented)

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -3202,7 +3202,7 @@ class NxtUndoStack(QtWidgets.QUndoStack):
         """
         model = getattr(command, 'model', None)  # type: StageModel
         if model and model.target_layer.get_locked():
-            logger.error('The target layer is locked!')
+            logger.warning('The target layer is locked!')
             model.request_ding.emit()
             return
         super(NxtUndoStack, self).push(command)

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -3203,6 +3203,7 @@ class NxtUndoStack(QtWidgets.QUndoStack):
         model = getattr(command, 'model', None)  # type: StageModel
         if model and model.target_layer.get_locked():
             logger.error('The target layer is locked!')
+            model.request_ding.emit()
             return
         super(NxtUndoStack, self).push(command)
 

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -813,8 +813,14 @@ class StageView(QtWidgets.QGraphicsView):
             self._previous_mouse_pos = event.pos()
             event.accept()
             return
-
         super(StageView, self).mouseMoveEvent(event)
+        item = self.itemAt(event.pos())
+        app = QtWidgets.QApplication
+        if item and hasattr(item, 'locked') and item.locked:
+            if not app.overrideCursor():
+                app.setOverrideCursor(QtCore.Qt.ForbiddenCursor)
+        else:
+            app.restoreOverrideCursor()
 
     def mouseReleaseEvent(self, event):
         was_just_zooming = self.zooming

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -730,15 +730,6 @@ class StageView(QtWidgets.QGraphicsView):
             not_intractable = self.model.get_node_locked(item_path)
             if not_intractable:
                 self._clicked_something_locked = True
-                # selection = self.scene().selectedItems()
-                # keep = []
-                # for i in selection:
-                #     _path = self.get_sel_path_for_graphic(i)
-                #     if _path and not self.model.get_node_locked(_path):
-                #         keep += [i]
-                # self.scene().selection
-
-
             # item interaction
             curr_sel = self.model.is_selected(item_path)
             mods = event.modifiers()
@@ -923,7 +914,7 @@ class StageView(QtWidgets.QGraphicsView):
                 if type(items_released_on[1]) is NodeGraphicsPlug:
                     dropped_plug = items_released_on[1]
                     dropped_node_path = dropped_plug.parentItem().node_path
-                    locked = dropped_plug.parentItem().locked
+                    locked = self.model.get_node_locked(dropped_node_path)
                     dropped_attr_name = dropped_plug.attr_name_represented
                     exec_attr_name = nxt_node.INTERNAL_ATTRS.EXECUTE_IN
                     if (dropped_attr_name not in nxt_node.INTERNAL_ATTRS.ALL

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -73,6 +73,7 @@ class USER_PREF():
     ANIMATION = 'animation'
     SHOW_DBL_CLICK_MSG = 'show_double_click_message'
     SHOW_CE_DATA_STATE = 'show_code_editor_data_state'
+    DING = 'ding'
 
 
 class EDITOR_CACHE():


### PR DESCRIPTION
`+` Layer locking.
`*` Slightly rounded node corners.
`...` Modified `LabelEdit` to have the concept of being read only.
`...` Refactored button names in the property editor to have consistent naming.

MVP for layer locking, still needs testing to make sure every case is accounted for. Still lacking node and attr locking.

Blocked by: https://github.com/nxt-dev/nxt/pull/88

---

![image](https://user-images.githubusercontent.com/54835354/129422479-5355a233-2277-4b44-89a2-4825f1c1574e.png)

