### PR TITLE
Easy Builtin Graph Referencing

### DIFF
--- a/examples/make_cube_spin.nxt
+++ b/examples/make_cube_spin.nxt
@@ -1,0 +1,89 @@
+{
+    "version": "1.17",
+    "alias": "make_cube_spin",
+    "color": "#5285a6",
+    "mute": false,
+    "solo": false,
+    "meta_data": {
+        "positions": {
+            "/README": [
+                340.0,
+                -120.0
+            ],
+            "/make_cube": [
+                0.0,
+                0.0
+            ],
+            "/playblast_it": [
+                620.0,
+                0.0
+            ],
+            "/spin_it": [
+                320.0,
+                0.0
+            ]
+        }
+    },
+    "nodes": {
+        "/": {
+            "child_order": [
+                "spin_it",
+                "playblast_it",
+                "README"
+            ],
+            "attrs": {
+                "cube": {
+                    "type": "raw",
+                    "value": "MyAmazingCube"
+                }
+            },
+            "code": [
+                "from maya import cmds"
+            ]
+        },
+        "/README": {
+            "code": [
+                "\"\"\"",
+                "If you have the Maya plugin installed fire up Maya, activate the nxt_maya plugin.",
+                "",
+                "To run this graph remotely outside of Maya you'll want to create a context for Maya ",
+                "Navigate to `nxt > Create Maya Context`",
+                "Make note of the name you gave your Maya context (I named mine maya2020) and either open your terminal and run:",
+                "    ",
+                "    nxt exec ${file::make_cube_spin.nxt} --context maya2020",
+                "    ",
+                "or from open a new Python file and use run the following script:",
+                "    ",
+                "    import nxt",
+                "    nxt.execute_graph('${file::make_cube_spin.nxt}', context='maya2020')",
+                "",
+                "\"\"\""
+            ]
+        },
+        "/make_cube": {
+            "start_point": true,
+            "comment": "Create a poly cube and store it's name on the STAGE",
+            "code": [
+                "cmds.select(cl=True)",
+                "STAGE.cube, shape = cmds.polyCube(n='${cube}')"
+            ]
+        },
+        "/playblast_it": {
+            "execute_in": "/spin_it",
+            "comment": "Playblast the cube and open the viewer to see it",
+            "code": [
+                "cmds.select(cl=True)",
+                "cmds.viewFit(\"persp\")",
+                "cmds.playblast(st=1, et=59, format=\"image\", viewer=True)"
+            ]
+        },
+        "/spin_it": {
+            "execute_in": "/make_cube",
+            "comment": "Add some keyframes to the cube",
+            "code": [
+                "cmds.setKeyframe('${cube}', at='.ry', v=0.0, t=1)",
+                "cmds.setKeyframe('${cube}', at='.ry', v=360, t=60)"
+            ]
+        }
+    }
+}

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -1,6 +1,5 @@
 # Builtin
 import os
-import sys
 import logging
 import sys
 
@@ -79,8 +78,11 @@ def launch_editor(paths=None, start_rpc=True):
         paths.pop(0)
     else:
         paths = []
-    app = QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication
+    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
+    app = app(sys.argv)
     style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
     style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
     stream = QtCore.QTextStream(style_file)

--- a/nxt_editor/dockwidgets/layer_manager.py
+++ b/nxt_editor/dockwidgets/layer_manager.py
@@ -194,6 +194,11 @@ class LayerTreeView(QtWidgets.QTreeView):
         menu.addAction(self.actions.ref_layer_above_action)
         self.actions.ref_layer_below_action.setData(layer)
         menu.addAction(self.actions.ref_layer_below_action)
+        menu.addSeparator()
+        builtins_menu = QtWidgets.QMenu('Reference Builtin Graph')
+        nxt_editor.main_window.populate_builtins_menu(qmenu=builtins_menu,
+                                                      main_window=self.actions.main_window)
+        menu.addMenu(builtins_menu)
         menu.popup(QtGui.QCursor.pos())
 
 


### PR DESCRIPTION
`+` Added `Reference Builtin Graph` menu for easily referencing builtin graphs under your target layer.
Possible bug fix for weird scale issues on Centos 7.
Added example graph.