### PR TITLE
Holiday Editor Fixes

### DIFF
--- a/integration/maya/plug-ins/nxt_maya.py
+++ b/integration/maya/plug-ins/nxt_maya.py
@@ -21,6 +21,7 @@ import nxt_editor.main_window
 import nxt.remote.nxt_socket
 from nxt import nxt_log
 from nxt_editor.constants import NXT_WEBSITE
+from nxt.constants import NXT_DCC_ENV_VAR
 
 logger = logging.getLogger('nxt')
 CREATED_UI = []
@@ -97,6 +98,7 @@ class NxtUiCmd(om.MPxCommand):
 
     def doIt(self, args):
         global __NXT_INSTANCE__
+        os.environ[NXT_DCC_ENV_VAR] = 'maya'
         if args:
             string_args = []
             for arg in range(len(args)):

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -54,11 +54,24 @@ def make_resources(qrc_path=None, result_path=None):
     try:
         subprocess.check_call(['pyside2-rcc'] + args)
     except:
-        try:
-            subprocess.check_call([full_rcc_path] + args)
-        except:
-            raise Exception("Cannot find pyside2-rcc to generate UI resources."
-                            " Reinstalling pyside2 may fix the problem.")
+        pass
+    else:
+        return
+
+    try:
+        subprocess.check_call([full_rcc_path] + args)
+    except:
+        pass
+    else:
+        return
+
+    try:
+        subprocess.check_call(['rcc', '-g', 'python', qrc_path, result_path])
+    except:
+        raise Exception("Cannot find pyside2 rcc to generate UI resources."
+                        " Reinstalling pyside2 may fix the problem.")
+    else:
+        return
 
 
 try:
@@ -68,30 +81,43 @@ except ImportError:
 
 
 def launch_editor(paths=None, start_rpc=True):
-    """Creates a new QApplication with editor main window and shows it.
+    """Launch an instance of the editor. Will attach to existing QApp if found,
+    otherwise will create and open one.
     """
-    # Deferred import since main window relies on us
-    from nxt_editor.main_window import MainWindow
+    existing = QtWidgets.QApplication.instance()
+    if existing:
+        app = existing
+    else:
+        app = QtWidgets.QApplication
+        os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+        app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+        app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
+        app = app(sys.argv)
+        style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
+        style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
+        stream = QtCore.QTextStream(style_file)
+        app.setStyleSheet(stream.readAll())
+        pixmap = QtGui.QPixmap(':icons/icons/nxt.svg')
+        app.setWindowIcon(QtGui.QIcon(pixmap))
+    instance = show_new_editor(paths, start_rpc)
+    app.setActiveWindow(instance)
+    if not existing:
+        app.exec_()
+    return app
+
+
+def show_new_editor(paths=None, start_rpc=True):
     path = None
     if paths is not None:
         path = paths[0]
         paths.pop(0)
     else:
         paths = []
-    app = QtWidgets.QApplication
-    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
-    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
-    app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
-    app = app(sys.argv)
-    style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
-    style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
-    stream = QtCore.QTextStream(style_file)
-    app.setStyleSheet(stream.readAll())
+    # Deferred import since main window relies on us
+    from nxt_editor.main_window import MainWindow
     instance = MainWindow(filepath=path, start_rpc=start_rpc)
     for other_path in paths:
         instance.load_file(other_path)
-    pixmap = QtGui.QPixmap(':icons/icons/nxt.svg')
-    app.setWindowIcon(QtGui.QIcon(pixmap))
-    app.setActiveWindow(instance)
     instance.show()
-    return app.exec_()
+    return instance
+

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -805,8 +805,12 @@ class PropertyEditor(DockWidgetBase):
     def edit_instance(self):
         comp_layer = self.stage_model.comp_layer
         target_layer = self.stage_model.target_layer
+        if self.stage_model.node_exists(self.node_path, target_layer):
+            lookup_layer = target_layer
+        else:
+            lookup_layer = comp_layer
         cur_inst_path = self.stage_model.get_node_instance_path(self.node_path,
-                                                                target_layer,
+                                                                lookup_layer,
                                                                 expand=False)
         instance_path = str(self.instance_field.text())
         if (not cur_inst_path and not instance_path

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -32,7 +32,8 @@ from nxt import nxt_log, nxt_io, nxt_layer
 from nxt_editor.dialogs import (NxtFileDialog, NxtWarningDialog,
                                 UnsavedLayersDialogue, UnsavedChangesMessage)
 from nxt_editor import actions, LoggingSignaler
-from nxt.constants import API_VERSION, GRAPH_VERSION, USER_PLUGIN_DIR
+from nxt.constants import (API_VERSION, GRAPH_VERSION, USER_PLUGIN_DIR,
+                           NXT_DCC_ENV_VAR, is_standalone)
 from nxt.remote.client import NxtClient
 import nxt.remote.contexts
 from nxt_editor import qresources
@@ -83,9 +84,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 # logger.exception("Could not determine git branch.")
                 current_branch = ''
         os.chdir(old_cwd)
-        context = nxt.remote.contexts.get_current_context_exe_name()
-        if context.lower() == 'python':
+        if is_standalone():
             context = 'standalone'
+        else:
+            context = os.environ.get(NXT_DCC_ENV_VAR) or ''
         self.host_app = context
         self.setWindowTitle("nxt {} - Editor v{} | Graph v{} | API v{} "
                             "(Python {}) {}".format(self.host_app,
@@ -1086,7 +1088,7 @@ class MenuBar(QtWidgets.QMenuBar):
                                                            'Context')
         remote_context_func = self.main_window.create_remote_context
         remote_context_action.triggered.connect(remote_context_func)
-        if nxt.remote.contexts.get_current_context_exe_name() == 'maya':
+        if not is_standalone():
             remote_context_action.setEnabled(False)
         self.remote_menu.addSeparator()
         self.remote_menu.addAction(self.exec_actions.enable_cmd_port_action)

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -532,6 +532,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.model.effected_layers.remove(layer.real_path)
         except KeyError:  # Layer may not have been changed
             pass
+        self.model.layer_saved.emit(layer.real_path)
         self.set_waiting_cursor(False)
 
     def save_layer_as(self, layer=None, open_in_new_tab=True):

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -12,7 +12,7 @@ from Qt import QtWidgets
 from Qt import QtCore
 
 # Internal
-from nxt import clean_json
+from nxt import clean_json, nxt_io
 from nxt_editor.commands import *
 from nxt_editor.dialogs import NxtFileDialog
 from nxt.constants import API_VERSION, is_standalone
@@ -20,7 +20,7 @@ from nxt import (nxt_path, nxt_layer, tokens, DATA_STATE,
                  NODE_ERRORS, GRID_SIZE)
 import nxt_editor
 from nxt_editor import DIRECTIONS, StringSignaler
-from nxt.nxt_layer import LAYERS, CompLayer
+from nxt.nxt_layer import LAYERS, CompLayer, SAVE_KEY
 from nxt.nxt_node import (get_node_attr, META_ATTRS, get_node_as_dict,
                           get_node_enabled)
 from nxt.stage import (determine_nxt_type, INTERNAL_ATTRS,
@@ -61,6 +61,7 @@ class StageModel(QtCore.QObject):
     layer_alias_changed = QtCore.Signal(str)  # Layer path whose alias changed
     layer_removed = QtCore.Signal(str)  # Layer path who was removed
     layer_added = QtCore.Signal(str)  # Layer path who was added
+    layer_saved = QtCore.Signal(str)  # Layer path that was just saved
     nodes_changed = QtCore.Signal(tuple)
     attrs_changed = QtCore.Signal(tuple)
     node_added = QtCore.Signal(str)
@@ -3058,7 +3059,7 @@ class StageModel(QtCore.QObject):
                 disc_data = json.dumps(disc_data, indent=4, sort_keys=True)
                 if live_data != disc_data:
                     unsaved_layers.add(layer)
-        elif self.undo_stack.canUndo():
+        elif self.undo_stack.count():
             for layer_path in self.effected_layers:
                 layer = self.lookup_layer(layer_path)
                 if layer and layer not in unsaved_layers:

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1510,6 +1510,15 @@ class StageModel(QtCore.QObject):
             logger.error('You should use revert instance path, you can not '
                          'set an instance path to NoneType.')
             return
+        expanded_inst_path = nxt_path.expand_relative_node_path(instance_path,
+                                                                node_path)
+        return_path = self.comp_layer.RETURNS.Path
+        ancestors = self.comp_layer.ancestors(node_path,
+                                              return_type=return_path,
+                                              include_implied=True)
+        if expanded_inst_path in ancestors:
+            logger.error('Can not instance an ancestor!')
+            return
         cmd = SetNodeInstance(node_path=node_path,
                               instance_path=instance_path, model=self,
                               layer_path=layer_path)


### PR DESCRIPTION
`*` Bug Fix, If a layer was saved and then a command undo altered the layer, it would not again marked as unsaved. Fixes #117
`*` Bug fix, clicking in and out of instance path would cause the node to localize.
`*` Updated `launch_editor` to work in an environment where a QApp is already running.
`*` Bug fix, `qresources` failed to generate if using `PySide2 v5.15`.
`*` Bug Fix, Attempting to instance an ancestor would cause the editor to freeze.
`...` Implemented `is_standalone` in editor.
`...` Maya plugin now sets its dcc name in the environment (only used right now by `MainWindow` to set its title)