### PR TITLE
Release editor-v3.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,52 @@
-# Overview
+# NXT Editor
 
-**nxt** (**/ɛn·ɛks·ti/**) is a general purpose code compositor designed for rigging, scene assembly, and automation. (node execution tree)
+**nxt** (**/ɛn·ɛks·ti/**) is a general purpose code compositor designed for rigging, scene assembly, and automation. (node execution tree)  
+[Installation/Usage](#installationusage) | [Docs](https://nxt-devs.github.io/) | [Contributing](CONTRIBUTING.md) | [Licensing](LICENSE)
+
+# Installation/Usage
+**To Use NXT please use the [NXT Standalone](#nxt-standalone) or [DCC plugin zip.](#maya-plugin)**  
+Only clone this repo if you're [contributing](CONTRIBUTING.md) to the NXT codebase.
+
+<br>
+
+#### Requirements
+- Python >= [2.7.*](https://www.python.org/download/releases/2.7) <= [3.7.*](https://www.python.org/download/releases/3.7)
+- We strongly recommend using a Python [virtual environment](https://docs.python.org/3.7/tutorial/venv.html)
+
+*[Requirements for contributors](CONTRIBUTING.md#python-environment)*  
+
+### NXT Standalone
+Our releases are hosted on [PyPi](https://pypi.org/project/nxt-editor/).
+- Install:
+    - `pip install nxt-editor`
+- Launch:
+    - `nxt ui`
+- Update:
+    - `pip install -U nxt-editor`
+
+### Maya plugin:
+
+- Install:
+    1. Download the maya module(`nxt_maya.zip`) from the [latest release](https://github.com/nxt-dev/nxt_editor/releases/latest)
+    2. Follow the [nxt_maya](integration/maya/README.md) instructions (also included in the download)
+- Launch:
+    1. Load `nxt_maya` plugin in Maya
+    2. Select the `nxt` menu from the menus at the top of Maya
+    3. Click `Open Editor`
+- Update:
+    1. Download the `nxt_maya` zip from the [latest release](https://github.com/nxt-dev/nxt_editor/releases/latest)
+    2. Extract the zip and replace the existing `nxt_maya` files with the newly extracted files.
+    3. Re-launch Maya
+
+<br>
+
+## Special Thanks
+
+[Sunrise Productions](https://sunriseproductions.tv/) | [School of Visual Art and Design](https://www.southern.edu/visualartanddesign/)
+
+---
 
 | Release | Dev |
 | :---: | :---: |
 | ![Build Status](https://travis-ci.com/nxt-dev/nxt_editor.svg?token=rBRbAJTv2rq1c8WVEwGs&branch=release) | ![Build Status](https://travis-ci.com/nxt-dev/nxt_editor.svg?token=rBRbAJTv2rq1c8WVEwGs&branch=dev) |
 
-# Links
-
-- [Installation](#installation)
-- [Updating](#updating)
-- [User Docs](https://sunriseproductions.github.io/nxt/)
-- [Contributing](CONTRIBUTING.md)
-- [Licensing](LICENSE)
-
-
-
-# Installation
-
-### Requirements
-- Python >= [2.7.*](https://www.python.org/download/releases/2.7) <= [3.7.*](https://www.python.org/download/releases/3.7)
-
-
-### PIP package
-- From [PyPi](https://pypi.org/project/nxt-editor/):
-    - `pip install nxt-editor`
-
-### Maya plugin:
-
-1. Download the maya module(`nxt_maya.zip`) from the [latest release](https://github.com/SunriseProductions/nxt_editor/releases/latest)
-
-2. Follow the [nxt_maya](integration/maya/README.md) instructions (also included in the download)
-
-# Updating
-
-### PIP package
-- From [PyPi](https://pypi.org/project/nxt-editor/):
-    - `pip install -U nxt-editor`
-
-### Maya plugin:
-
-1. Download the `nxt_maya` zip from the [latest release](https://github.com/SunriseProductions/nxt_editor/releases/latest)
-
-2. Extract the zip and replace the existing nxt_maya files with the newly extracted files.
-
-3. Re-launch Maya
-
-
-## Acknowledgements
-
-[Sunrise Productions](https://sunriseproductions.tv/) | [School of Visual Art and Design](https://www.southern.edu/visualartanddesign/)

--- a/build/validate_version_numbers.nxt
+++ b/build/validate_version_numbers.nxt
@@ -106,31 +106,6 @@
     },
     "nodes": {
         "/": {
-            "child_order": [
-                "CheckCommits",
-                "ValidatePushed",
-                "CreateRelease",
-                "BeginPR",
-                "ParseGitReturn",
-                "ParseGitReturn2",
-                "GitCmd",
-                "GitCmd2",
-                "CheckoutRelease",
-                "JsonLoad2",
-                "BeginRelease",
-                "GitCurBranch2",
-                "CheckoutWorking",
-                "make_package",
-                "GenerateHotkeysMD",
-                "make_module_folder",
-                "UpdateReleasePR",
-                "GenerateChangelog",
-                "ParseVersionJSON",
-                "ValidateWorking",
-                "ParseVersions",
-                "init",
-                "ValidateVersion"
-            ],
             "attrs": {
                 "EDITOR": {
                     "type": "NoneType",

--- a/examples/make_cube_spin.nxt
+++ b/examples/make_cube_spin.nxt
@@ -1,0 +1,89 @@
+{
+    "version": "1.17",
+    "alias": "make_cube_spin",
+    "color": "#5285a6",
+    "mute": false,
+    "solo": false,
+    "meta_data": {
+        "positions": {
+            "/README": [
+                340.0,
+                -120.0
+            ],
+            "/make_cube": [
+                0.0,
+                0.0
+            ],
+            "/playblast_it": [
+                620.0,
+                0.0
+            ],
+            "/spin_it": [
+                320.0,
+                0.0
+            ]
+        }
+    },
+    "nodes": {
+        "/": {
+            "child_order": [
+                "spin_it",
+                "playblast_it",
+                "README"
+            ],
+            "attrs": {
+                "cube": {
+                    "type": "raw",
+                    "value": "MyAmazingCube"
+                }
+            },
+            "code": [
+                "from maya import cmds"
+            ]
+        },
+        "/README": {
+            "code": [
+                "\"\"\"",
+                "If you have the Maya plugin installed fire up Maya, activate the nxt_maya plugin.",
+                "",
+                "To run this graph remotely outside of Maya you'll want to create a context for Maya ",
+                "Navigate to `nxt > Create Maya Context`",
+                "Make note of the name you gave your Maya context (I named mine maya2020) and either open your terminal and run:",
+                "    ",
+                "    nxt exec ${file::make_cube_spin.nxt} --context maya2020",
+                "    ",
+                "or from open a new Python file and use run the following script:",
+                "    ",
+                "    import nxt",
+                "    nxt.execute_graph('${file::make_cube_spin.nxt}', context='maya2020')",
+                "",
+                "\"\"\""
+            ]
+        },
+        "/make_cube": {
+            "start_point": true,
+            "comment": "Create a poly cube and store it's name on the STAGE",
+            "code": [
+                "cmds.select(cl=True)",
+                "STAGE.cube, shape = cmds.polyCube(n='${cube}')"
+            ]
+        },
+        "/playblast_it": {
+            "execute_in": "/spin_it",
+            "comment": "Playblast the cube and open the viewer to see it",
+            "code": [
+                "cmds.select(cl=True)",
+                "cmds.viewFit(\"persp\")",
+                "cmds.playblast(st=1, et=59, format=\"image\", viewer=True)"
+            ]
+        },
+        "/spin_it": {
+            "execute_in": "/make_cube",
+            "comment": "Add some keyframes to the cube",
+            "code": [
+                "cmds.setKeyframe('${cube}', at='.ry', v=0.0, t=1)",
+                "cmds.setKeyframe('${cube}', at='.ry', v=360, t=60)"
+            ]
+        }
+    }
+}

--- a/integration/maya/plug-ins/nxt_maya.py
+++ b/integration/maya/plug-ins/nxt_maya.py
@@ -21,6 +21,7 @@ import nxt_editor.main_window
 import nxt.remote.nxt_socket
 from nxt import nxt_log
 from nxt_editor.constants import NXT_WEBSITE
+from nxt.constants import NXT_DCC_ENV_VAR
 
 logger = logging.getLogger('nxt')
 CREATED_UI = []
@@ -97,6 +98,7 @@ class NxtUiCmd(om.MPxCommand):
 
     def doIt(self, args):
         global __NXT_INSTANCE__
+        os.environ[NXT_DCC_ENV_VAR] = 'maya'
         if args:
             string_args = []
             for arg in range(len(args)):

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -1,6 +1,5 @@
 # Builtin
 import os
-import sys
 import logging
 import sys
 
@@ -79,8 +78,11 @@ def launch_editor(paths=None, start_rpc=True):
         paths.pop(0)
     else:
         paths = []
-    app = QtWidgets.QApplication(sys.argv)
+    app = QtWidgets.QApplication
+    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
+    app = app(sys.argv)
     style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
     style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
     stream = QtCore.QTextStream(style_file)

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -54,11 +54,24 @@ def make_resources(qrc_path=None, result_path=None):
     try:
         subprocess.check_call(['pyside2-rcc'] + args)
     except:
-        try:
-            subprocess.check_call([full_rcc_path] + args)
-        except:
-            raise Exception("Cannot find pyside2-rcc to generate UI resources."
-                            " Reinstalling pyside2 may fix the problem.")
+        pass
+    else:
+        return
+
+    try:
+        subprocess.check_call([full_rcc_path] + args)
+    except:
+        pass
+    else:
+        return
+
+    try:
+        subprocess.check_call(['rcc', '-g', 'python', qrc_path, result_path])
+    except:
+        raise Exception("Cannot find pyside2 rcc to generate UI resources."
+                        " Reinstalling pyside2 may fix the problem.")
+    else:
+        return
 
 
 try:
@@ -68,30 +81,43 @@ except ImportError:
 
 
 def launch_editor(paths=None, start_rpc=True):
-    """Creates a new QApplication with editor main window and shows it.
+    """Launch an instance of the editor. Will attach to existing QApp if found,
+    otherwise will create and open one.
     """
-    # Deferred import since main window relies on us
-    from nxt_editor.main_window import MainWindow
+    existing = QtWidgets.QApplication.instance()
+    if existing:
+        app = existing
+    else:
+        app = QtWidgets.QApplication
+        os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+        app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+        app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
+        app = app(sys.argv)
+        style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
+        style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
+        stream = QtCore.QTextStream(style_file)
+        app.setStyleSheet(stream.readAll())
+        pixmap = QtGui.QPixmap(':icons/icons/nxt.svg')
+        app.setWindowIcon(QtGui.QIcon(pixmap))
+    instance = show_new_editor(paths, start_rpc)
+    app.setActiveWindow(instance)
+    if not existing:
+        app.exec_()
+    return app
+
+
+def show_new_editor(paths=None, start_rpc=True):
     path = None
     if paths is not None:
         path = paths[0]
         paths.pop(0)
     else:
         paths = []
-    app = QtWidgets.QApplication
-    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
-    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
-    app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
-    app = app(sys.argv)
-    style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
-    style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
-    stream = QtCore.QTextStream(style_file)
-    app.setStyleSheet(stream.readAll())
+    # Deferred import since main window relies on us
+    from nxt_editor.main_window import MainWindow
     instance = MainWindow(filepath=path, start_rpc=start_rpc)
     for other_path in paths:
         instance.load_file(other_path)
-    pixmap = QtGui.QPixmap(':icons/icons/nxt.svg')
-    app.setWindowIcon(QtGui.QIcon(pixmap))
-    app.setActiveWindow(instance)
     instance.show()
-    return app.exec_()
+    return instance
+

--- a/nxt_editor/commands.py
+++ b/nxt_editor/commands.py
@@ -945,7 +945,7 @@ class ParentNodes(NxtCommand):
         self.node_path_data = self.stage.parent_nodes(nodes,
                                                       self.parent_node_path,
                                                       layer)
-        self.new_node_paths = self.node_path_data.values()
+        self.new_node_paths = list(self.node_path_data.values())
         idx = 0
         for new_node_path in self.new_node_paths:
             old_node_path = self.node_paths[idx]
@@ -962,7 +962,7 @@ class ParentNodes(NxtCommand):
             idx += 1
         self.model.update_comp_layer(rebuild=True)
 
-        self.model.selection = self.node_path_data.values()
+        self.model.selection = list(self.node_path_data.values())
         if len(self.node_paths) == 1:
             path_str = self.node_paths[0]
         else:

--- a/nxt_editor/dockwidgets/layer_manager.py
+++ b/nxt_editor/dockwidgets/layer_manager.py
@@ -194,6 +194,11 @@ class LayerTreeView(QtWidgets.QTreeView):
         menu.addAction(self.actions.ref_layer_above_action)
         self.actions.ref_layer_below_action.setData(layer)
         menu.addAction(self.actions.ref_layer_below_action)
+        menu.addSeparator()
+        builtins_menu = QtWidgets.QMenu('Reference Builtin Graph')
+        nxt_editor.main_window.populate_builtins_menu(qmenu=builtins_menu,
+                                                      main_window=self.actions.main_window)
+        menu.addMenu(builtins_menu)
         menu.popup(QtGui.QCursor.pos())
 
 

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -805,8 +805,12 @@ class PropertyEditor(DockWidgetBase):
     def edit_instance(self):
         comp_layer = self.stage_model.comp_layer
         target_layer = self.stage_model.target_layer
+        if self.stage_model.node_exists(self.node_path, target_layer):
+            lookup_layer = target_layer
+        else:
+            lookup_layer = comp_layer
         cur_inst_path = self.stage_model.get_node_instance_path(self.node_path,
-                                                                target_layer,
+                                                                lookup_layer,
                                                                 expand=False)
         instance_path = str(self.instance_field.text())
         if (not cur_inst_path and not instance_path

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -1466,6 +1466,8 @@ class AttrsTableView(QtWidgets.QTableView):
             drag = QtGui.QDrag(self)
             mime_data = QtCore.QMimeData()
             attr_name = self.get_attr_name()
+            if attr_name is None:
+                return
             token = tokens.make_token_str(attr_name)
             mime_data.setText(token)
             drag.setMimeData(mime_data)

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -32,7 +32,8 @@ from nxt import nxt_log, nxt_io, nxt_layer
 from nxt_editor.dialogs import (NxtFileDialog, NxtWarningDialog,
                                 UnsavedLayersDialogue, UnsavedChangesMessage)
 from nxt_editor import actions, LoggingSignaler
-from nxt.constants import API_VERSION, GRAPH_VERSION, USER_PLUGIN_DIR
+from nxt.constants import (API_VERSION, GRAPH_VERSION, USER_PLUGIN_DIR,
+                           NXT_DCC_ENV_VAR, is_standalone)
 from nxt.remote.client import NxtClient
 import nxt.remote.contexts
 from nxt_editor import qresources
@@ -83,9 +84,10 @@ class MainWindow(QtWidgets.QMainWindow):
                 # logger.exception("Could not determine git branch.")
                 current_branch = ''
         os.chdir(old_cwd)
-        context = nxt.remote.contexts.get_current_context_exe_name()
-        if context.lower() == 'python':
+        if is_standalone():
             context = 'standalone'
+        else:
+            context = os.environ.get(NXT_DCC_ENV_VAR) or ''
         self.host_app = context
         self.setWindowTitle("nxt {} - Editor v{} | Graph v{} | API v{} "
                             "(Python {}) {}".format(self.host_app,
@@ -1086,7 +1088,7 @@ class MenuBar(QtWidgets.QMenuBar):
                                                            'Context')
         remote_context_func = self.main_window.create_remote_context
         remote_context_action.triggered.connect(remote_context_func)
-        if nxt.remote.contexts.get_current_context_exe_name() == 'maya':
+        if not is_standalone():
             remote_context_action.setEnabled(False)
         self.remote_menu.addSeparator()
         self.remote_menu.addAction(self.exec_actions.enable_cmd_port_action)

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -532,6 +532,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self.model.effected_layers.remove(layer.real_path)
         except KeyError:  # Layer may not have been changed
             pass
+        self.model.layer_saved.emit(layer.real_path)
         self.set_waiting_cursor(False)
 
     def save_layer_as(self, layer=None, open_in_new_tab=True):

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -1426,7 +1426,7 @@ class RecentFilesMenu(QtWidgets.QMenu):
             action = self.addAction('No recents found')
             action.setEnabled(False)
         for file_path in recents:
-            self.addAction(file_path)
+            self.addAction(str(file_path))
 
     def recent_selected(self, action):
         self.action_target(action.text())

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -1228,7 +1228,8 @@ class MenuBar(QtWidgets.QMenuBar):
         ui_dir = os.path.dirname(__file__)
         resources_file = os.path.join(ui_dir, 'qresources.py').replace(os.sep,
                                                                       '/')
-        resources_file_c = os.path.join(ui_dir, 'qresources.pyc').replace('/')
+        resources_file_c = os.path.join(ui_dir, 'qresources.pyc').replace(os.sep,
+                                                                          '/')
         success = False
         if os.path.isfile(resources_file):
             try:

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -239,12 +239,15 @@ class NodeGraphicsItem(QtWidgets.QGraphicsItem):
                 painter.setBrush(brush)
             else:
                 painter.setBrush(color.darker(self.dim_factor))
-            if i != color_count - 1:
-                painter.drawRect(i*color_band_width, 0, color_band_width,
+            # Top Opinion
+            if i+1 == color_count:
+                remaining_width = self.max_width - (i*color_band_width)
+                painter.drawRect(0, 0, remaining_width,
                                  self.title_rect_height)
+            # Lower Opinions
             else:
-                remaining_width = self.max_width - i*color_band_width
-                painter.drawRect(i*color_band_width, 0, remaining_width,
+                x_pos = self.max_width - (i+1)*color_band_width
+                painter.drawRect(x_pos, 0, color_band_width,
                                  self.title_rect_height)
         painter.setBackground(bg)
         painter.setBackgroundMode(bgm)

--- a/nxt_editor/resources/LICENSE.FEATHERICONS
+++ b/nxt_editor/resources/LICENSE.FEATHERICONS
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -12,7 +12,7 @@ from Qt import QtWidgets
 from Qt import QtCore
 
 # Internal
-from nxt import clean_json
+from nxt import clean_json, nxt_io
 from nxt_editor.commands import *
 from nxt_editor.dialogs import NxtFileDialog
 from nxt.constants import API_VERSION, is_standalone
@@ -20,7 +20,7 @@ from nxt import (nxt_path, nxt_layer, tokens, DATA_STATE,
                  NODE_ERRORS, GRID_SIZE)
 import nxt_editor
 from nxt_editor import DIRECTIONS, StringSignaler
-from nxt.nxt_layer import LAYERS, CompLayer
+from nxt.nxt_layer import LAYERS, CompLayer, SAVE_KEY
 from nxt.nxt_node import (get_node_attr, META_ATTRS, get_node_as_dict,
                           get_node_enabled)
 from nxt.stage import (determine_nxt_type, INTERNAL_ATTRS,
@@ -61,6 +61,7 @@ class StageModel(QtCore.QObject):
     layer_alias_changed = QtCore.Signal(str)  # Layer path whose alias changed
     layer_removed = QtCore.Signal(str)  # Layer path who was removed
     layer_added = QtCore.Signal(str)  # Layer path who was added
+    layer_saved = QtCore.Signal(str)  # Layer path that was just saved
     nodes_changed = QtCore.Signal(tuple)
     attrs_changed = QtCore.Signal(tuple)
     node_added = QtCore.Signal(str)
@@ -3058,7 +3059,7 @@ class StageModel(QtCore.QObject):
                 disc_data = json.dumps(disc_data, indent=4, sort_keys=True)
                 if live_data != disc_data:
                     unsaved_layers.add(layer)
-        elif self.undo_stack.canUndo():
+        elif self.undo_stack.count():
             for layer_path in self.effected_layers:
                 layer = self.lookup_layer(layer_path)
                 if layer and layer not in unsaved_layers:

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2532,24 +2532,36 @@ class StageModel(QtCore.QObject):
         self.about_to_execute.emit(True)
         rt_layer = rt_layer or self.current_rt_layer
         path_mismatch = False
+        valid_node = True
         reset_cache_now = False
         if rt_layer:
             rt_paths = set(rt_layer.descendants())
             comp_paths = set(self.comp_layer.descendants())
             path_mismatch = comp_paths.difference(rt_paths)
+            valid_node = bool(rt_layer.lookup(node_path))
         if path_mismatch:
             logger.error("{} invalid node(s) in the runtime "
                          "layer.".format(len(path_mismatch)))
             title = "Invalid cache node(s)!"
-            info = ("Some nodes from the runtime layer are invalid.\n"
-                    "Would you like to rebuild the runtime layer?\n"
-                    "Cache data will be lost!".format(node_path))
+
+            if valid_node:
+                cancel_text = 'Ignore and Continue'
+                info = ("Some nodes from the runtime layer are invalid.\n"
+                        "Would you like to rebuild the runtime layer?\n"
+                        "Cache data will be lost!")
+            else:
+                info = ("`{}`\nis not present in the current runtime "
+                        "layer.\nWould you like to rebuild the runtime "
+                        "layer?\nCache data will be lost!".format(node_path))
+                cancel_text = 'Cancel Execute'
             button_text = {QtWidgets.QMessageBox.Ok: 'Rebuild',
-                           QtWidgets.QMessageBox.Cancel: 'Ignore and Continue'}
+                           QtWidgets.QMessageBox.Cancel: cancel_text}
             confirm = NxtConfirmDialog.show_message(title, info,
                                                     button_text=button_text)
             if confirm:
                 reset_cache_now = True
+            elif not valid_node:
+                return
         if not rt_layer or reset_cache_now:
             temp_comp = self.stage.build_stage(self.comp_layer.layer_idx())
             rt_layer = self.stage.setup_runtime_layer(temp_comp)
@@ -2558,8 +2570,8 @@ class StageModel(QtCore.QObject):
         self._set_executing(True)
         try:
             self.stage.execute_custom_code(code_string, node_path, rt_layer)
-        except GraphError:
-            pass
+        except GraphError as err:
+            logger.grapherror(str(err), links=[node_path])
         self._set_executing(False)
 
     def validate_socket_connection(self):

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1510,6 +1510,15 @@ class StageModel(QtCore.QObject):
             logger.error('You should use revert instance path, you can not '
                          'set an instance path to NoneType.')
             return
+        expanded_inst_path = nxt_path.expand_relative_node_path(instance_path,
+                                                                node_path)
+        return_path = self.comp_layer.RETURNS.Path
+        ancestors = self.comp_layer.ancestors(node_path,
+                                              return_type=return_path,
+                                              include_implied=True)
+        if expanded_inst_path in ancestors:
+            logger.error('Can not instance an ancestor!')
+            return
         cmd = SetNodeInstance(node_path=node_path,
                               instance_path=instance_path, model=self,
                               layer_path=layer_path)

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -2,6 +2,6 @@
   "EDITOR": {
     "MAJOR": 3,
     "MINOR": 4,
-    "PATCH": 3
+    "PATCH": 4
   }
 }


### PR DESCRIPTION
## Additions:
`+` Added `Reference Builtin Graph` menu for easily referencing builtin graphs under your target layer.
## Changes:
`*` Bug fix, unable to undo parent command in Python 3.
`*` Bug fix, When executing a code snippet the user wasn't prevented from attempting to run an invalid runtime node. There is a clearer warning dialog now and no attempt to execute code is made.
`*` Bug fix, errors raised during exec of code snippets wouldn't get logged.
`*` Bug fix, in rare cases an exception was raised when nxt thought the user was dragging an attr but they were actually clicking away.
`*` Bug fix, `delete_resources_pyc` had a syntax error.
`*` Bug fix, clicking in and out of instance path would cause the node to localize.
`*` Updated `launch_editor` to work in an environment where a QApp is already running.
`*` Bug fix, `qresources` failed to generate if using `PySide2 v5.15`.
`*` swapped direction of layer display on node graphics
`*` Bug Fix, Fixed crash when trying to open recent files menu after switching interpreter from Py2 to Py3.
`*` Bug Fix, If a layer was saved and then a command undo altered the layer, it would not again marked as unsaved.
`*` Bug Fix, Attempting to instance an ancestor would cause the editor to freeze.
## Notes:
`...` Implemented `is_standalone` in editor.
`...` Maya plugin now sets its dcc name in the environment (only used right now by MainWindow to set its title)
