### PR TITLE
Release editor-v3.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,6 @@ script:
     fi
   - |
     if [ "$TRAVIS_BRANCH" = "release" ] && [ "$TRAVIS_EVENT_TYPE" = "push" ]; then
-          python -m nxt.cli exec nxt/build/packaging.nxt -s /make_and_upload
+          python -m nxt.cli exec nxt_editor/build/packaging.nxt -s /make_and_upload
           exit $?
     fi

--- a/nxt_editor/dialogs.py
+++ b/nxt_editor/dialogs.py
@@ -374,7 +374,7 @@ class NxtWarningDialog(QtWidgets.QDialog):
 
 class NxtConfirmDialog(QtWidgets.QMessageBox):
     def __init__(self, text='Title', info='Confirm something!',
-                 button_text=None):
+                 button_text=None, icon=QtWidgets.QMessageBox.Icon.Question):
         """Simple message box used for user confirmation
         :param text: Title text
         :param info: Main info text
@@ -386,7 +386,7 @@ class NxtConfirmDialog(QtWidgets.QMessageBox):
         self.setText(text)
         self.setInformativeText(info)
         self.setStandardButtons(self.Ok)
-        self.setIcon(self.Icon.Question)
+        self.setIcon(icon)
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         self.setStandardButtons(self.Ok | self.Cancel)
         if button_text:

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2541,42 +2541,14 @@ class StageModel(QtCore.QObject):
         :return: None
         """
         self.about_to_execute.emit(True)
-        rt_layer = rt_layer or self.current_rt_layer
-        path_mismatch = False
-        valid_node = True
-        reset_cache_now = False
-        if rt_layer:
-            rt_paths = set(rt_layer.descendants())
-            comp_paths = set(self.comp_layer.descendants())
-            path_mismatch = comp_paths.difference(rt_paths)
-            valid_node = bool(rt_layer.lookup(node_path))
-        if path_mismatch:
-            logger.error("{} invalid node(s) in the runtime "
-                         "layer.".format(len(path_mismatch)))
-            title = "Invalid cache node(s)!"
-
-            if valid_node:
-                cancel_text = 'Ignore and Continue'
-                info = ("Some nodes from the runtime layer are invalid.\n"
-                        "Would you like to rebuild the runtime layer?\n"
-                        "Cache data will be lost!")
-            else:
-                info = ("`{}`\nis not present in the current runtime "
-                        "layer.\nWould you like to rebuild the runtime "
-                        "layer?\nCache data will be lost!".format(node_path))
-                cancel_text = 'Cancel Execute'
-            button_text = {QtWidgets.QMessageBox.Ok: 'Rebuild',
-                           QtWidgets.QMessageBox.Cancel: cancel_text}
-            confirm = NxtConfirmDialog.show_message(title, info,
-                                                    button_text=button_text)
-            if confirm:
-                reset_cache_now = True
-            elif not valid_node:
-                return
-        if not rt_layer or reset_cache_now:
-            temp_comp = self.stage.build_stage(self.comp_layer.layer_idx())
-            rt_layer = self.stage.setup_runtime_layer(temp_comp)
-            self.current_rt_layer = rt_layer
+        rt = rt_layer
+        np = [node_path]
+        valid, bad_paths = self.validate_runtime_layer(rt_layer=rt,
+                                                       node_paths=np)
+        if not rt_layer or not valid:
+            new_rt = self.prompt_runtime_rebuild(must_rebuild=bool(bad_paths))
+            if new_rt:
+                rt_layer = new_rt
         rt_layer._console.run_as_global = globally
         self._set_executing(True)
         try:
@@ -2584,6 +2556,56 @@ class StageModel(QtCore.QObject):
         except GraphError as err:
             logger.grapherror(str(err), links=[node_path])
         self._set_executing(False)
+
+    def validate_runtime_layer(self, rt_layer=None,
+                               comp_layer=None, node_paths=()):
+        rt_layer = rt_layer or self.current_rt_layer
+        comp_layer = comp_layer or self.comp_layer
+        paths_match = False
+        invalid_nodes = []
+        node_paths = list(node_paths)
+        if rt_layer and comp_layer:
+            rt_paths = set(rt_layer.descendants())
+            comp_paths = set(comp_layer.descendants())
+            path_diff = comp_paths.symmetric_difference(rt_paths)
+            paths_match = not bool(path_diff)
+            if not paths_match:
+                for p in node_paths:
+                    if bool(rt_layer.lookup(p)):
+                        invalid_nodes += [p]
+        all_nodes_valid = not invalid_nodes
+        if not all_nodes_valid:
+            logger.error("{} invalid node(s) in the runtime layer."
+                         "".format(len(invalid_nodes)))
+        valid = paths_match and all_nodes_valid
+        return valid, invalid_nodes
+
+    def prompt_runtime_rebuild(self, must_rebuild=False):
+        rt_layer = None
+        title = "Invalid runtime node(s)!"
+
+        if must_rebuild:
+            cancel_text = 'Ignore and Continue'
+            info = ("Some nodes from the runtime layer are invalid.\n"
+                    "Would you like to rebuild the runtime layer?\n"
+                    "Cache data will be lost!\n\n"
+                    "Ignoring this warning may result in graph errors!")
+        else:
+            info = ("Some node(s) are not present in the current runtime "
+                    "layer.\nWould you like to rebuild the runtime "
+                    "layer?\nCache data will be lost!")
+            cancel_text = 'Cancel Execute'
+        button_text = {QtWidgets.QMessageBox.Ok: 'Rebuild',
+                       QtWidgets.QMessageBox.Cancel: cancel_text}
+        icon = NxtConfirmDialog.Icon.Warning
+        confirm = NxtConfirmDialog.show_message(title, info,
+                                                button_text=button_text,
+                                                icon=icon)
+        if confirm:
+            temp_comp = self.stage.build_stage(self.comp_layer.layer_idx())
+            rt_layer = self.stage.setup_runtime_layer(temp_comp)
+            self.current_rt_layer = rt_layer
+        return rt_layer
 
     def validate_socket_connection(self):
         """Attempts a round trip, if the client gets its message and returns
@@ -2716,13 +2738,31 @@ class StageModel(QtCore.QObject):
                                                MODEL=nxt_socket.MODEL_VAR)
         self._send_cmd(cmd)
 
-    def execute_nodes(self, node_paths, rt_layer=None):
-        self.about_to_execute.emit(True)
+    def execute_nodes(self, node_paths, rt_layer=None, safe_exec=True):
+        """Executes given node paths in the given runtime layer. If no rt
+        layer is given a new one is built.
+
+        :param node_paths: list of node paths
+        :param rt_layer: CompLayer (must have self.runtime set to True)
+        :param safe_exec: If True the rt layer is validated against the comp
+        :return: CompLayer (the runtime layer that ran)
+        """
         if not node_paths:
             logger.error("No node paths specified for execution")
             return
+        if safe_exec and rt_layer:
+            np = node_paths
+            valid, bad_paths = self.validate_runtime_layer(rt_layer=rt_layer,
+                                                           node_paths=np)
+            if not valid:
+                rebuild = bool(bad_paths)
+                new_rt = self.prompt_runtime_rebuild(must_rebuild=rebuild)
+                if new_rt:
+                    rt_layer = self.current_rt_layer
+        self.about_to_execute.emit(True)
         self.setup_build(node_paths, rt_layer=rt_layer)
         self.resume_build()
+        return rt_layer
 
     def _execute_node(self, node_path):
         t = ExecuteNodeThread(self, node_path)

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -2,6 +2,6 @@
   "EDITOR": {
     "MAJOR": 3,
     "MINOR": 5,
-    "PATCH": 0
+    "PATCH": 1
   }
 }


### PR DESCRIPTION
## Changes:
`*` Bug fix, workflow tools, before executing, wouldn't properly warn users about changes to the comp and underlying runtime layer.
## Notes:
`...` `NxtConfirmDialog` now lets you customize the icon.
`...` Exec that fails due to invalid nodes will display an error dialog and exit the build
