### PR TITLE
Improved Blender Support +  Ez Blender Context

### DIFF
--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -95,7 +95,7 @@ def _new_qapp():
     return app
 
 
-def launch_editor(paths=None, start_rpc=True, call_exec=True):
+def launch_editor(paths=None, start_rpc=True):
     """Launch an instance of the editor. Will attach to existing QApp if found,
     otherwise will create and open one.
     """
@@ -106,7 +106,7 @@ def launch_editor(paths=None, start_rpc=True, call_exec=True):
         app = _new_qapp()
     instance = show_new_editor(paths, start_rpc)
     app.setActiveWindow(instance)
-    if not existing and call_exec:
+    if not existing:
         app.exec_()
     return instance
 

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -95,7 +95,7 @@ def _new_qapp():
     return app
 
 
-def launch_editor(paths=None, start_rpc=True):
+def launch_editor(paths=None, start_rpc=True, call_exec=True):
     """Launch an instance of the editor. Will attach to existing QApp if found,
     otherwise will create and open one.
     """
@@ -106,7 +106,7 @@ def launch_editor(paths=None, start_rpc=True):
         app = _new_qapp()
     instance = show_new_editor(paths, start_rpc)
     app.setActiveWindow(instance)
-    if not existing:
+    if not existing and call_exec:
         app.exec_()
     return instance
 

--- a/nxt_editor/integration/__init__.py
+++ b/nxt_editor/integration/__init__.py
@@ -100,13 +100,26 @@ class NxtIntegration(object):
         if self.check_for_nxt_editor():
             self._update_package('nxt-editor')
 
-    @ staticmethod
-    def uninstall():
+    @staticmethod
+    def _uninstall_package(package_name):
+        """Calls a subprocess to pip uninstall the given package name. Will
+        NOT prompt the user to confrim uninstall.
+
+        :param package_name: pip package name
+        :raises: subprocess.CalledProcessError
+        :return: None
+        """
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
         subprocess.run([sys.executable, "-m", "pip", "uninstall",
-                        "nxt-editor", "nxt-core"], check=True, env=environ_copy)
-        print('Please restart your DCC or Python interpreter')
+                        package_name, '-y'], check=True, env=environ_copy)
+
+    def uninstall(self):
+        if self.check_for_nxt_core():
+            self._uninstall_package('nxt-core')
+        if self.check_for_nxt_editor():
+            self._uninstall_package('nxt-editor')
+        # print('Please restart your DCC or Python interpreter')
 
     def launch_nxt(self):
         raise NotImplementedError('Your DCC needs it own nxt launch method.')

--- a/nxt_editor/integration/__init__.py
+++ b/nxt_editor/integration/__init__.py
@@ -1,5 +1,6 @@
 import os
-import shutil
+import sys
+import subprocess
 import importlib
 
 
@@ -32,29 +33,41 @@ class NxtIntegration(object):
 
     def _install_and_import_package(self, module_name, package_name=None,
                                     global_name=None):
+        """Calls a subprocess to pip install the given package name and then
+        attempts to import the new package.
+
+        :param module_name: Desired module to import after install
+        :param package_name: pip package name
+        :param global_name: Global name to access the module if different
+        than the module name.
+        :raises: subprocess.CalledProcessError
+        :return: bool
+        """
         if package_name is None:
             package_name = module_name
         if global_name is None:
             global_name = module_name
-        args = ['install', package_name]
-        self.ensure_pip()
-        import pip
-        if hasattr(pip, 'main'):
-            pip.main(['install', package_name])
-        else:
-            pip._internal.main(['install', package_name])
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        subprocess.run([sys.executable, "-m", "pip", "install",
+                        package_name], check=True, env=environ_copy)
+
         success = self._safe_import_package(package_name=package_name,
                                             global_name=global_name)
         return success
 
-    def _update_package(self, package_name):
-        args = ['install', '-U', package_name]
-        self.ensure_pip()
-        import pip
-        if hasattr(pip, 'main'):
-            pip.main(args)
-        else:
-            pip._internal.main(args)
+    @staticmethod
+    def _update_package(package_name):
+        """Calls a subprocess to pip update the given package name.
+
+        :param package_name: pip package name
+        :raises: subprocess.CalledProcessError
+        :return: None
+        """
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        subprocess.run([sys.executable, "-m", "pip", "install", "-U",
+                        package_name], check=True, env=environ_copy)
         print('Please restart your DCC or Python interpreter')
 
     def check_for_nxt_core(self, install=False):
@@ -81,51 +94,26 @@ class NxtIntegration(object):
             print('Failed to import and/or install nxt-editor')
         return success
 
-    @staticmethod
-    def ensure_pip():
-        try:
-            import pip
-        except ImportError:
-            import ensurepip
-            ensurepip.bootstrap()
-            os.environ.pop('PIP_REQ_TRACKER', None)
-
     def update(self):
         if self.check_for_nxt_core():
             self._update_package('nxt-core')
         if self.check_for_nxt_editor():
             self._update_package('nxt-editor')
 
+    @ staticmethod
+    def uninstall():
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        subprocess.run([sys.executable, "-m", "pip", "uninstall",
+                        "nxt-editor", "nxt-core"], check=True, env=environ_copy)
+        print('Please restart your DCC or Python interpreter')
 
-class Blender(NxtIntegration):
-    def __init__(self):
-        super(Blender, self).__init__(name='blender')
-        import bpy
-        b_major, b_minor, b_patch = bpy.app.version
-        if b_major != 2 or b_minor < 80:
-            raise RuntimeError('Blender version is not compatible with this '
-                               'version of nxt.')
-        user_dir = os.path.expanduser('~/AppData/Roaming/Blender '
-                                      'Foundation/Blender/'
-                                      '{}.{}'.format(b_major, b_minor))
-        self.user_dir = user_dir
-        nxt_modules = os.path.join(user_dir, 'scripts/addons/modules')
-        self.modules_dir = nxt_modules.replace(os.sep, '/')
+    def launch_nxt(self):
+        raise NotImplementedError('Your DCC needs it own nxt launch method.')
 
-    @classmethod
-    def setup(cls):
-        self = cls()
-        import bpy
-        bpy.ops.preferences.addon_disable(module='nxt_' + self.name)
-        addons_dir = os.path.join(self.user_dir, 'scripts/addons')
-        integration_filepath = self.get_integration_filepath()
-        shutil.copy(integration_filepath, addons_dir)
-        bpy.ops.preferences.addon_enable(module='nxt_' + self.name)
+    def quit_nxt(self):
+        raise NotImplementedError('Your DCC needs it own nxt quit method.')
 
-    @classmethod
-    def update(cls):
-        self = cls()
-        og_cwd = os.getcwd()
-        os.chdir(self.modules_dir)
-        super(Blender, self).update()
-        os.chdir(og_cwd)
+    def create_context(self):
+        raise NotImplementedError('Your DCC needs it own method of creating a '
+                                  'context.')

--- a/nxt_editor/integration/blender/__init__.py
+++ b/nxt_editor/integration/blender/__init__.py
@@ -1,0 +1,100 @@
+# Builtin
+import os
+import shutil
+import sys
+import atexit
+
+# External
+import bpy
+from Qt import QtCore, QtWidgets
+
+# Internal
+from nxt.constants import NXT_DCC_ENV_VAR
+from nxt_editor.integration import NxtIntegration
+import nxt_editor
+
+__NXT_INTEGRATION__ = None
+
+
+class Blender(NxtIntegration):
+    def __init__(self):
+        super(Blender, self).__init__(name='blender')
+        b_major, b_minor, b_patch = bpy.app.version
+        if b_major != 2 or b_minor < 80:
+            raise RuntimeError('Blender version is not compatible with this '
+                               'version of nxt.')
+        user_dir = os.path.expanduser('~/AppData/Roaming/Blender '
+                                      'Foundation/Blender/'
+                                      '{}.{}'.format(b_major, b_minor))
+        self.user_dir = user_dir
+        nxt_modules = os.path.join(user_dir, 'scripts/addons/modules')
+        self.modules_dir = nxt_modules.replace(os.sep, '/')
+        self.instance = None
+        self.nxt_qapp = QtWidgets.QApplication.instance()
+
+    @classmethod
+    def setup(cls):
+        self = cls()
+        bpy.ops.preferences.addon_disable(module='nxt_' + self.name)
+        addons_dir = os.path.join(self.user_dir, 'scripts/addons')
+        integration_filepath = self.get_integration_filepath()
+        shutil.copy(integration_filepath, addons_dir)
+        bpy.ops.preferences.addon_enable(module='nxt_' + self.name)
+
+    @classmethod
+    def update(cls):
+        self = cls()
+        og_cwd = os.getcwd()
+        os.chdir(self.modules_dir)
+        super(Blender, self).update()
+        os.chdir(og_cwd)
+
+    @classmethod
+    def launch_nxt(cls):
+        self = cls()
+        os.environ[NXT_DCC_ENV_VAR] = 'blender'
+        global __NXT_INTEGRATION__
+        if not __NXT_INTEGRATION__:
+            __NXT_INTEGRATION__ = self
+        else:
+            self = __NXT_INTEGRATION__
+        if self.instance:
+            self.instance.show()
+            return
+        if not self.nxt_qapp:
+            self.nxt_qapp = nxt_editor._new_qapp()
+            nxt_win = nxt_editor.show_new_editor(start_rpc=False)
+        else:
+            nxt_win = nxt_editor.show_new_editor(start_rpc=False)
+        if 'win32' in sys.platform:
+            # gives nxt it's own entry on taskbar
+            nxt_win.setWindowFlags(QtCore.Qt.Window)
+
+        def unregister_nxt():
+            self.instance = None
+            if self.nxt_qapp:
+                self.nxt_qapp.quit()
+                self.nxt_qapp = None
+
+        nxt_win.close_signal.connect(unregister_nxt)
+        nxt_win.show()
+        atexit.register(nxt_win.close)
+        self.instance = nxt_win
+        return self
+
+    def quit_nxt(self):
+        if self.instance:
+            self.instance.close()
+            atexit.unregister(self.instance.close)
+        if self.nxt_qapp:
+            self.nxt_qapp.quit()
+        global __NXT_INTEGRATION__
+        __NXT_INTEGRATION__ = None
+
+    def create_context(self):
+        placeholder_txt = 'Blender {}.{}'.format(*bpy.app.version)
+        args = ['-noaudio', '--background', '--python']
+        self.instance.create_remote_context(placeholder_txt,
+                                            interpreter_exe=bpy.app.binary_path,
+                                            exe_script_args=args)
+

--- a/nxt_editor/integration/blender/nxt_blender.py
+++ b/nxt_editor/integration/blender/nxt_blender.py
@@ -130,7 +130,6 @@ class NxtInstallDependencies(bpy.types.Operator):
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
         pkg = 'nxt-editor'
-        pkg = 'D:/Projects/nxt_editor'
         try:
             subprocess.run([sys.executable, "-m", "pip", "install", pkg],
                            check=True, env=environ_copy)
@@ -187,7 +186,7 @@ class NxtUninstallDependencies(bpy.types.Operator):
 
     def execute(self, context):
         try:
-            blender.Blender.uninstall()
+            blender.Blender().uninstall()
         except subprocess.CalledProcessError as e:
             self.report({"ERROR"}, str(e))
             return {"CANCELLED"}

--- a/nxt_editor/integration/blender/nxt_blender.py
+++ b/nxt_editor/integration/blender/nxt_blender.py
@@ -1,28 +1,41 @@
+"""
+Loosely based on the example addon from this repo:
+https://github.com/robertguetzkow/blender-python-examples
+"""
 # Builtin
 import os
 import sys
+import subprocess
 
 # External
-from Qt import QtCore, QtWidgets
 import bpy
 
-# Internal
-from nxt.constants import NXT_DCC_ENV_VAR
-from nxt_editor.constants import NXT_WEBSITE
-import nxt_editor.main_window
-import nxt_editor
-os.environ[NXT_DCC_ENV_VAR] = 'blender'
+try:
+    # External
+    from Qt import QtCore, QtWidgets
+    # Internal
+    from nxt_editor.constants import NXT_WEBSITE
+    from nxt_editor.integration import blender
+    nxt_installed = True
+except ImportError:
+    nxt_installed = False
+    NXT_WEBSITE = 'https://nxt-dev.github.io/'
+
+nxt_package_name = 'nxt-editor'
 
 bl_info = {
     "name": "NXT Blender",
     "blender": (2, 80, 0),
-    "version": (0, 1, 0),
+    "version": (0, 2, 0),
     "location": "NXT > Open Editor",
     "wiki_url": "https://nxt-dev.github.io/",
     "tracker_url": "https://github.com/nxt-dev/nxt_editor/issues",
     "category": "nxt",
-    "warning": "This is an experimental version of nxt_blender. Save early, "
-               "save often."
+    "description": "NXT is a general purpose code compositor designed for "
+                   "rigging, scene assembly, and automation. (This is an "
+                   "experimental version of nxt_blender. Save "
+                   "early, save often.)",
+    "warning": "This addon requires installation of dependencies."
 }
 
 
@@ -38,8 +51,20 @@ class BLENDER_PLUGIN_VERSION(object):
     VERSION = VERSION_STR
 
 
-__NXT_INSTANCE__ = None
-__NXT_CREATED_QAPP__ = None
+class CreateBlenderContext(bpy.types.Operator):
+    bl_label = "Create Remote Blender NXT Context"
+    bl_idname = "nxt.create_blender_context"
+
+    def execute(self, context):
+        global nxt_installed
+        if nxt_installed:
+            b = blender.__NXT_INTEGRATION__
+            if not b:
+                b = blender.Blender.launch_nxt()
+            b.create_context()
+        else:
+            show_dependency_warning()
+        return {'FINISHED'}
 
 
 class OpenNxtEditor(bpy.types.Operator):
@@ -47,36 +72,11 @@ class OpenNxtEditor(bpy.types.Operator):
     bl_idname = "nxt.nxt_editor"
 
     def execute(self, context):
-        global __NXT_INSTANCE__
-        global __NXT_CREATED_QAPP__
-        if __NXT_INSTANCE__:
-            __NXT_INSTANCE__.show()
-            return
-        if not __NXT_CREATED_QAPP__:
-            nxt_win = nxt_editor.launch_editor()
+        global nxt_installed
+        if nxt_installed:
+            blender.Blender.launch_nxt()
         else:
-            nxt_win = nxt_editor.show_new_editor()
-        if 'win32' in sys.platform:
-            # gives nxt it's own entry on taskbar
-            nxt_win.setWindowFlags(QtCore.Qt.Window)
-
-        def unregister_nxt():
-            global __NXT_INSTANCE__
-            __NXT_INSTANCE__ = None
-
-        nxt_win.close_signal.connect(unregister_nxt)
-        nxt_win.show()
-        __NXT_INSTANCE__ = nxt_win
-        return {'FINISHED'}
-
-
-class UpdateNxt(bpy.types.Operator):
-    bl_label = "Update NXT"
-    bl_idname = "nxt.nxt_update"
-
-    def execute(self, context):
-        import nxt_editor.integration
-        nxt_editor.integration.Blender.update()
+            show_dependency_warning()
         return {'FINISHED'}
 
 
@@ -97,8 +97,11 @@ class TOPBAR_MT_nxt(bpy.types.Menu):
         layout = self.layout
         layout.operator("nxt.nxt_editor", text="Open Editor")
         layout.separator()
-        layout.operator("nxt.nxt_update", text="Update NXT (Requires Blender "
-                                               "Restart)")
+        layout.operator("nxt.nxt_update_dependencies",
+                        text="Update NXT (Requires Blender Restart)")
+        layout.separator()
+        layout.operator('nxt.create_blender_context', text='Create Blender '
+                                                           'Context')
         layout.separator()
         layout.operator("nxt.nxt_about", text="About")
 
@@ -106,34 +109,148 @@ class TOPBAR_MT_nxt(bpy.types.Menu):
         self.layout.menu("TOPBAR_MT_nxt")
 
 
-nxt_menu_operators = (TOPBAR_MT_nxt, OpenNxtEditor)
+class NxtInstallDependencies(bpy.types.Operator):
+    bl_idname = 'nxt.nxt_install_dependencies'
+    bl_label = "Install NXT dependencies"
+    bl_description = ("Downloads and installs the required python packages "
+                      "for NXT. Internet connection is required. "
+                      "Blender may have to be started with elevated "
+                      "permissions in order to install the package. "
+                      "Alternatively you can pip install nxt-editor into your "
+                      "Blender Python environment.")
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    @classmethod
+    def poll(cls, context):
+        global nxt_installed
+        return not nxt_installed
+
+    def execute(self, context):
+        success = False
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        pkg = 'nxt-editor'
+        pkg = 'D:/Projects/nxt_editor'
+        try:
+            subprocess.run([sys.executable, "-m", "pip", "install", pkg],
+                           check=True, env=environ_copy)
+        except subprocess.CalledProcessError as e:
+            self.report({"ERROR"}, str(e))
+            return {"CANCELLED"}
+        if not success:
+            self.report({"INFO"}, 'Please restart Blender to '
+                                  'finish installing NXT.')
+        return {"FINISHED"}
+
+
+class NxtUpdateDependencies(bpy.types.Operator):
+    bl_idname = 'nxt.nxt_update_dependencies'
+    bl_label = "Update NXT dependencies"
+    bl_description = ("Downloads and updates the required python packages "
+                      "for NXT. Internet connection is required. "
+                      "Blender may have to be started with elevated "
+                      "permissions in order to install the package. "
+                      "Alternatively you can pip install -U nxt-editor into "
+                      "your Blender Python environment.")
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    @classmethod
+    def poll(cls, context):
+        global nxt_installed
+        return nxt_installed
+
+    def execute(self, context):
+        try:
+            blender.Blender._update_package('nxt-editor')
+        except subprocess.CalledProcessError as e:
+            self.report({"ERROR"}, str(e))
+            return {"CANCELLED"}
+        self.report({"INFO"}, 'Please restart Blender to '
+                              'finish updating NXT.')
+        return {"FINISHED"}
+
+
+class NxtUninstallDependencies(bpy.types.Operator):
+    bl_idname = 'nxt.nxt_uninstall_dependencies'
+    bl_label = "Uninstall NXT dependencies"
+    bl_description = ("Uninstalls the NXT Python packages. "
+                      "Blender may have to be started with elevated "
+                      "permissions in order to install the package. "
+                      "Alternatively you can pip uninstall nxt-editor from "
+                      "your Blender Python environment.")
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    @classmethod
+    def poll(cls, context):
+        global nxt_installed
+        return nxt_installed
+
+    def execute(self, context):
+        try:
+            blender.Blender.uninstall()
+        except subprocess.CalledProcessError as e:
+            self.report({"ERROR"}, str(e))
+            return {"CANCELLED"}
+        self.report({"INFO"}, 'Please restart Blender to '
+                              'finish uninstalling NXT dependencies.')
+        return {"FINISHED"}
+
+
+class NxtDependenciesPreferences(bpy.types.AddonPreferences):
+    bl_idname = __name__
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator(NxtInstallDependencies.bl_idname, icon="PLUGIN")
+        layout.operator(NxtUpdateDependencies.bl_idname, icon="SCRIPT")
+        layout.operator(NxtUninstallDependencies.bl_idname, icon="PANEL_CLOSE")
+
+
+def show_dependency_warning():
+
+    def draw(self, context):
+        layout = self.layout
+        lines = [
+            f"Please install the missing dependencies for the NXT add-on.",
+            "1. Open the preferences (Edit > Preferences > Add-ons).",
+            f"2. Search for the \"{bl_info.get('name')}\" add-on.",
+            "3. Open the details section of the add-on.",
+            f"4. Click on the \"{NxtInstallDependencies.bl_label}\" button.",
+            "This will download and install the missing Python packages. "
+            "You man need to start Blender with elevated permissions",
+            f"Alternatively you can pip install \"{nxt_package_name}\" into "
+            f"your Blender Python environment."
+        ]
+
+        for line in lines:
+            layout.label(text=line)
+    bpy.context.window_manager.popup_menu(draw, title='NXT Warning!',
+                                          icon="ERROR")
+
+
+nxt_operators = (TOPBAR_MT_nxt, OpenNxtEditor, NxtUpdateDependencies,
+                 NxtUninstallDependencies, NxtDependenciesPreferences,
+                 NxtInstallDependencies, CreateBlenderContext)
 
 
 def register():
-    global __NXT_CREATED_QAPP__
-    existing = QtWidgets.QApplication.instance()
-    if existing:
-        __NXT_CREATED_QAPP__ = False
-    else:
-        __NXT_CREATED_QAPP__ = True
-        nxt_editor._new_qapp()
-    bpy.utils.register_class(TOPBAR_MT_nxt)
-    bpy.utils.register_class(OpenNxtEditor)
+    global nxt_installed
+    for cls in nxt_operators:
+        bpy.utils.register_class(cls)
     bpy.utils.register_class(AboutNxt)
-    bpy.utils.register_class(UpdateNxt)
     bpy.types.TOPBAR_MT_editor_menus.append(TOPBAR_MT_nxt.menu_draw)
 
 
 def unregister():
-    global __NXT_CREATED_QAPP__
-    if __NXT_CREATED_QAPP__:
-        QtWidgets.QApplication.instance().quit()
-        __NXT_CREATED_QAPP__ = False
+    try:
+        if blender.__NXT_INTEGRATION__:
+            blender.__NXT_INTEGRATION__.quit_nxt()
+    except NameError:
+        pass
     bpy.types.TOPBAR_MT_editor_menus.remove(TOPBAR_MT_nxt.menu_draw)
-    bpy.utils.unregister_class(TOPBAR_MT_nxt)
-    bpy.utils.unregister_class(OpenNxtEditor)
+    for cls in nxt_operators:
+        bpy.utils.unregister_class(cls)
     bpy.utils.unregister_class(AboutNxt)
-    bpy.utils.unregister_class(UpdateNxt)
 
 
 if __name__ == "__main__":

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -337,15 +337,15 @@ class MainWindow(QtWidgets.QMainWindow):
     @staticmethod
     def create_remote_context(place_holder_text='',
                               interpreter_exe=sys.executable,
-                              context_graph=None):
+                              context_graph=None, exe_script_args=()):
         cur_context = nxt.remote.contexts.get_current_context_exe_name()
         pop_up = QtWidgets.QDialog()
         pop_up.setWindowTitle('Create context for "{}"'.format(cur_context))
         v_layout = QtWidgets.QVBoxLayout()
         pop_up.setLayout(v_layout)
         label = QtWidgets.QPlainTextEdit()
-        info = ('Create context for "{}" your host '
-                'python interpreter\n'
+        info = ('Create remote context for your host '
+                'Python interpreter/DCC\n'
                 'Type your desired name in the box below '
                 'and click create.'.format(cur_context))
         label.setPlainText(info)
@@ -358,6 +358,7 @@ class MainWindow(QtWidgets.QMainWindow):
         v_layout.addLayout(h_layout)
         name = QtWidgets.QLineEdit()
         name.setPlaceholderText(str(place_holder_text))
+        name.setText(str(place_holder_text))
         create_button = QtWidgets.QPushButton('Create!')
         h_layout.addWidget(name)
         h_layout.addWidget(create_button)
@@ -366,7 +367,8 @@ class MainWindow(QtWidgets.QMainWindow):
             try:
                 nxt.create_context(name.text(),
                                    interpreter_exe=interpreter_exe,
-                                   context_graph=context_graph)
+                                   context_graph=context_graph,
+                                   exe_script_args=exe_script_args)
                 pop_up.close()
             except (IOError, NameError) as e:
                 info = str(e)


### PR DESCRIPTION
`+` One click Blender context.
`+` Support for contexts that aren't strictly Python interpreters.
`*` Centralized blender integration functions into a single class that can be called without the addon being loaded.
`*` `launch_editor` now has a kwarg to NOT call `app.exec_()`, needed for host DCCs that aren't themselves a QApp.
`...` Switched to using `subprocess` as the pip approach.