### PR TITLE
Minor UX Patches

### DIFF
--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -1767,12 +1767,30 @@ class CodeEditorActions(NxtActionContainer):
         self.run_line_global_action.setAutoRepeat(False)
         self.run_line_global_action.setShortcutContext(context)
         self.run_line_global_action.setShortcut('Ctrl+Shift+Return')
+        self.run_line_global_action.setShortcutContext(context)
+
+        self.overlay_message_action = NxtAction('Show Double Click Message',
+                                                parent=self)
+        self.overlay_message_action.setAutoRepeat(False)
+        self.overlay_message_action.setCheckable(True)
+        state = user_dir.user_prefs.get(user_dir.USER_PREF.SHOW_DBL_CLICK_MSG,
+                                        True)
+        self.overlay_message_action.setChecked(state)
+
+        def toggle_dbl_click_msg():
+            old = self.overlay_message_action.isChecked()
+            new = not old
+            user_dir.user_prefs[user_dir.USER_PREF.SHOW_DBL_CLICK_MSG] = new
+            self.main_window.code_editor.overlay_widget.update()
+
+        self.overlay_message_action.toggled.connect(toggle_dbl_click_msg)
 
         self.action_display_order = [self.copy_resolved_action,
                                      self.localize_code_action,
                                      self.revert_code_action,
                                      self.font_bigger, self.font_smaller,
                                      self.font_size_revert,
+                                     self.overlay_message_action,
                                      self.new_line, self.indent_line,
                                      self.unindent_line,
                                      self.run_line_global_action,

--- a/nxt_editor/dockwidgets/code_editor.py
+++ b/nxt_editor/dockwidgets/code_editor.py
@@ -11,7 +11,7 @@ from Qt import QtCore
 from nxt_editor.dockwidgets.dock_widget_base import DockWidgetBase
 from nxt_editor.pixmap_button import PixmapButton
 from nxt_editor.label_edit import LabelEdit
-from nxt_editor import colors
+from nxt_editor import colors, user_dir
 from nxt_editor.decorator_widgets import OpinionDots
 from nxt import DATA_STATE, nxt_path
 from nxt.nxt_node import INTERNAL_ATTRS
@@ -1301,10 +1301,12 @@ class OverlayWidget(QtWidgets.QWidget):
         painter.drawText(self.rect().right() - offset,
                          painter.font().pointSize() * 1.5, self.data_state)
         # Draw center message text
-        msg_offset = font_metrics.boundingRect(self.click_msg).width()
-        msg_offset += painter.font().pointSize()
-        painter.drawText(self.rect().center().x() - (msg_offset*.5),
-                         self.rect().center().y(), self.click_msg)
+        show_msg = self._parent.ce_actions.overlay_message_action.isChecked()
+        if show_msg:
+            msg_offset = font_metrics.boundingRect(self.click_msg).width()
+            msg_offset += painter.font().pointSize()
+            painter.drawText(self.rect().center().x() - (msg_offset*.5),
+                             self.rect().center().y(), self.click_msg)
         painter.setCompositionMode(QtGui.QPainter.CompositionMode_Darken)
         path = QtGui.QPainterPath()
         path.addRoundedRect(QtCore.QRectF(self.rect()), 9, 9)

--- a/nxt_editor/dockwidgets/widget_builder.py
+++ b/nxt_editor/dockwidgets/widget_builder.py
@@ -100,9 +100,19 @@ class WidgetBuilder(DockWidgetBase):
         self.scroll_layout.setSpacing(4)
         self.scroll_layout.setAlignment(QtCore.Qt.AlignTop)
         self.scroll_widget.setLayout(self.scroll_layout)
+        # Context menu
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.context_menu)
 
         # update
         self.update_window()
+
+    def context_menu(self):
+        menu = QtWidgets.QMenu(self)
+        refresh_action = menu.addAction('Refresh')
+        refresh_action.triggered.connect(self.update_window)
+        menu.addAction(self.main_window.execute_actions.wt_recomp_action)
+        menu.popup(QtGui.QCursor.pos())
 
     def show(self):
         super(WidgetBuilder, self).show()

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -1075,8 +1075,11 @@ class MenuBar(QtWidgets.QMenuBar):
         self.view_menu.addSeparator()
         self.view_menu.addAction(self.view_actions.implicit_action)
         self.view_menu.addAction(self.view_actions.grid_action)
-        self.view_menu.addAction(self.view_actions.tooltip_action)
-        self.view_menu.addAction(self.layer_actions.lay_manger_table_action)
+        self.view_opt_menu = self.view_menu.addMenu('Options')
+        self.view_opt_menu.setTearOffEnabled(True)
+        self.view_opt_menu.addAction(self.view_actions.tooltip_action)
+        self.view_opt_menu.addAction(self.layer_actions.lay_manger_table_action)
+        self.view_opt_menu.addAction(self.ce_actions.overlay_message_action)
 
         # graph menu
         self.graph_menu = self.addMenu('Graph')

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1633,7 +1633,7 @@ class StageModel(QtCore.QObject):
         layer = layer or self.comp_layer
         ancestors = layer.ancestors(node_path)
         for ancestor in ancestors:
-            if not get_node_enabled(ancestor):
+            if not self.get_node_enabled(ancestor, layer=layer):
                 return False
         return True
 

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1320,6 +1320,8 @@ class StageModel(QtCore.QObject):
         """
         layer = layer or self.comp_layer
         node = layer.lookup(node_path)
+        if not node:
+            return
         source_layer = self.stage.get_node_source_layer(node)
         return source_layer
 

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -71,6 +71,7 @@ class USER_PREF():
     FPS = 'fps'
     LOD = 'lod'
     ANIMATION = 'animation'
+    SHOW_DBL_CLICK_MSG = 'show_double_click_message'
 
 
 class EDITOR_CACHE():


### PR DESCRIPTION
`+` Added helpful context menu to workflow tools
`+` Added preference for hiding "Double Click To Edit" message. See `View > Options > Show Double Click Message`
`*` Moved some view options into a sub menu for cleanliness
`*` Bug fix: Right clicking on an implied node would cause an error.
`*` Bug fix: `model.get_node_ancestor_enabled` would return unexpected `False`