### PR TITLE
Release editor-v3.8.0

### DIFF
--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -1778,8 +1778,7 @@ class CodeEditorActions(NxtActionContainer):
         self.overlay_message_action.setChecked(state)
 
         def toggle_dbl_click_msg():
-            old = self.overlay_message_action.isChecked()
-            new = not old
+            new = self.overlay_message_action.isChecked()
             user_dir.user_prefs[user_dir.USER_PREF.SHOW_DBL_CLICK_MSG] = new
             self.main_window.code_editor.overlay_widget.update()
 

--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -1767,12 +1767,30 @@ class CodeEditorActions(NxtActionContainer):
         self.run_line_global_action.setAutoRepeat(False)
         self.run_line_global_action.setShortcutContext(context)
         self.run_line_global_action.setShortcut('Ctrl+Shift+Return')
+        self.run_line_global_action.setShortcutContext(context)
+
+        self.overlay_message_action = NxtAction('Show Double Click Message',
+                                                parent=self)
+        self.overlay_message_action.setAutoRepeat(False)
+        self.overlay_message_action.setCheckable(True)
+        state = user_dir.user_prefs.get(user_dir.USER_PREF.SHOW_DBL_CLICK_MSG,
+                                        True)
+        self.overlay_message_action.setChecked(state)
+
+        def toggle_dbl_click_msg():
+            old = self.overlay_message_action.isChecked()
+            new = not old
+            user_dir.user_prefs[user_dir.USER_PREF.SHOW_DBL_CLICK_MSG] = new
+            self.main_window.code_editor.overlay_widget.update()
+
+        self.overlay_message_action.toggled.connect(toggle_dbl_click_msg)
 
         self.action_display_order = [self.copy_resolved_action,
                                      self.localize_code_action,
                                      self.revert_code_action,
                                      self.font_bigger, self.font_smaller,
                                      self.font_size_revert,
+                                     self.overlay_message_action,
                                      self.new_line, self.indent_line,
                                      self.unindent_line,
                                      self.run_line_global_action,

--- a/nxt_editor/dockwidgets/code_editor.py
+++ b/nxt_editor/dockwidgets/code_editor.py
@@ -11,7 +11,7 @@ from Qt import QtCore
 from nxt_editor.dockwidgets.dock_widget_base import DockWidgetBase
 from nxt_editor.pixmap_button import PixmapButton
 from nxt_editor.label_edit import LabelEdit
-from nxt_editor import colors
+from nxt_editor import colors, user_dir
 from nxt_editor.decorator_widgets import OpinionDots
 from nxt import DATA_STATE, nxt_path
 from nxt.nxt_node import INTERNAL_ATTRS
@@ -1301,10 +1301,12 @@ class OverlayWidget(QtWidgets.QWidget):
         painter.drawText(self.rect().right() - offset,
                          painter.font().pointSize() * 1.5, self.data_state)
         # Draw center message text
-        msg_offset = font_metrics.boundingRect(self.click_msg).width()
-        msg_offset += painter.font().pointSize()
-        painter.drawText(self.rect().center().x() - (msg_offset*.5),
-                         self.rect().center().y(), self.click_msg)
+        show_msg = self._parent.ce_actions.overlay_message_action.isChecked()
+        if show_msg:
+            msg_offset = font_metrics.boundingRect(self.click_msg).width()
+            msg_offset += painter.font().pointSize()
+            painter.drawText(self.rect().center().x() - (msg_offset*.5),
+                             self.rect().center().y(), self.click_msg)
         painter.setCompositionMode(QtGui.QPainter.CompositionMode_Darken)
         path = QtGui.QPainterPath()
         path.addRoundedRect(QtCore.QRectF(self.rect()), 9, 9)

--- a/nxt_editor/dockwidgets/hotkey_editor.py
+++ b/nxt_editor/dockwidgets/hotkey_editor.py
@@ -434,8 +434,9 @@ class KeySequenceEdit(QtWidgets.QLineEdit):
                 key = modifier_key_map[key]
                 keySequence = QtGui.QKeySequence(key)
                 text = keySequence.toString()
-
-            self.setText(text.encode())
+            if not isinstance(text, str):
+                text = text.decode()
+            self.setText(text)
             return
         else:
             if event_modifiers & QtCore.Qt.ShiftModifier:

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -958,7 +958,7 @@ class PropertyEditor(DockWidgetBase):
         cur_inst_path = self.stage_model.get_node_instance_path(self.node_path,
                                                                 comp_layer,
                                                                 expand=False)
-        if cur_inst_path:
+        if cur_inst_path is not None:
             self.stage_model.revert_node_instance(self.node_path)
         self.instance_field.blockSignals(False)
 

--- a/nxt_editor/dockwidgets/widget_builder.py
+++ b/nxt_editor/dockwidgets/widget_builder.py
@@ -100,9 +100,19 @@ class WidgetBuilder(DockWidgetBase):
         self.scroll_layout.setSpacing(4)
         self.scroll_layout.setAlignment(QtCore.Qt.AlignTop)
         self.scroll_widget.setLayout(self.scroll_layout)
+        # Context menu
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.context_menu)
 
         # update
         self.update_window()
+
+    def context_menu(self):
+        menu = QtWidgets.QMenu(self)
+        refresh_action = menu.addAction('Refresh')
+        refresh_action.triggered.connect(self.update_window)
+        menu.addAction(self.main_window.execute_actions.wt_recomp_action)
+        menu.popup(QtGui.QCursor.pos())
 
     def show(self):
         super(WidgetBuilder, self).show()

--- a/nxt_editor/dockwidgets/widget_builder.py
+++ b/nxt_editor/dockwidgets/widget_builder.py
@@ -864,8 +864,11 @@ class Button(QtWidgets.QPushButton):
                 attr_name=self.INPUT_LIST_ATTR,
                 layer=None,
                 data_state=DATA_STATE.CACHED)
-        items = ast.literal_eval(input_value) if input_value else []
-
+        if (not isinstance(input_value, str) and
+                isinstance(input_value, Iterable)):
+            items = input_value
+        else:
+            items = []
         # selector dialog
         screen = QtWidgets.QApplication.desktop().screenNumber(
             QtWidgets.QApplication.desktop().cursor().pos())

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -261,6 +261,16 @@ class MainWindow(QtWidgets.QMainWindow):
         # Should this be a signal? Like Startup done, now you can refresh?
         self.splash_screen.finish(self)
         self.in_startup = False
+        t = QtCore.QTimer()
+        t.setInterval(256)
+
+        def failure_check():
+            if self.view:
+                self.view.failure_check()
+            t.stop()
+        t.timeout.connect(failure_check)
+        t.start()
+
         app = QtWidgets.QApplication.instance()
         app.aboutToQuit.connect(self.shutdown_rpc_server)
 

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -1075,8 +1075,11 @@ class MenuBar(QtWidgets.QMenuBar):
         self.view_menu.addSeparator()
         self.view_menu.addAction(self.view_actions.implicit_action)
         self.view_menu.addAction(self.view_actions.grid_action)
-        self.view_menu.addAction(self.view_actions.tooltip_action)
-        self.view_menu.addAction(self.layer_actions.lay_manger_table_action)
+        self.view_opt_menu = self.view_menu.addMenu('Options')
+        self.view_opt_menu.setTearOffEnabled(True)
+        self.view_opt_menu.addAction(self.view_actions.tooltip_action)
+        self.view_opt_menu.addAction(self.layer_actions.lay_manger_table_action)
+        self.view_opt_menu.addAction(self.ce_actions.overlay_message_action)
 
         # graph menu
         self.graph_menu = self.addMenu('Graph')

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -1151,11 +1151,12 @@ class ErrorItem(QtWidgets.QGraphicsTextItem):
         return QtCore.QRectF(-10, -10, 10, 10)
 
     def paint(self, painter, option, widget):
-        painter.setRenderHints(QtGui.QPainter.Antialiasing | QtGui.QPainter.TextAntialiasing)
+        painter.setRenderHints(QtGui.QPainter.Antialiasing |
+                               QtGui.QPainter.TextAntialiasing)
         painter.setPen(QtCore.Qt.NoPen)
         painter.setBrush(colors.ERROR)
         painter.drawEllipse(0, 0, 20, 20)
         painter.setPen(QtCore.Qt.black)
         painter.setFont(self.font())
-        painter.setCompositionMode(QtGui.QPainter.CompositionMode_SourceOut)
-        painter.drawText(QtCore.QRectF(0.6, 0.1, 20, 20), QtCore.Qt.AlignCenter, self.text)
+        painter.drawText(QtCore.QRectF(0.6, 0.1, 20, 20), QtCore.Qt.AlignCenter,
+                         self.text)

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -335,6 +335,10 @@ class NodeGraphicsItem(graphic_type):
         painter.setPen(QtCore.Qt.NoPen)
         bg = painter.background()
         bgm = painter.backgroundMode()
+        if self.error_item:
+            self.scene().removeItem(self.error_item)
+            self.error_item.deleteLater()
+        self.error_item = None
         if self.is_real:
             painter.setBackgroundMode(QtCore.Qt.OpaqueMode)
         else:
@@ -471,11 +475,6 @@ class NodeGraphicsItem(graphic_type):
                 error_item.setParentItem(self)
                 error_item.setZValue(50)
                 self.error_item = error_item
-            else:
-                if self.error_item:
-                    self.scene().removeItem(self.error_item)
-                    self.error_item.deleteLater()
-                self.error_item = None
 
         # draw collapse state arrow
         for arrow in self.collapse_arrows:

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1521,6 +1521,10 @@ class StageModel(QtCore.QObject):
         if expanded_inst_path in ancestors:
             logger.error('Can not instance an ancestor!')
             return
+        dependants = self.comp_layer.get_node_dirties(node_path)
+        if expanded_inst_path in dependants:
+            logger.error('Can not instance a dependant node!')
+            return
         cmd = SetNodeInstance(node_path=node_path,
                               instance_path=instance_path, model=self,
                               layer_path=layer_path)

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1633,7 +1633,7 @@ class StageModel(QtCore.QObject):
         layer = layer or self.comp_layer
         ancestors = layer.ancestors(node_path)
         for ancestor in ancestors:
-            if not get_node_enabled(ancestor):
+            if not self.get_node_enabled(ancestor, layer=layer):
                 return False
         return True
 

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1320,6 +1320,8 @@ class StageModel(QtCore.QObject):
         """
         layer = layer or self.comp_layer
         node = layer.lookup(node_path)
+        if not node:
+            return
         source_layer = self.stage.get_node_source_layer(node)
         return source_layer
 

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -15,6 +15,7 @@ from nxt import nxt_node, tokens
 from nxt_editor.node_graphics_item import (NodeGraphicsItem, NodeGraphicsPlug,
                                            _pyside_version)
 from nxt_editor.connection_graphics_item import AttrConnectionGraphic
+from nxt_editor.dialogs import NxtWarningDialog
 from nxt_editor.commands import *
 from .user_dir import USER_PREF, user_prefs
 
@@ -128,6 +129,7 @@ class StageView(QtWidgets.QGraphicsView):
         self.model.data_state_changed.connect(self.update_resolved)
         self.model.layer_color_changed.connect(self.update_view)
         self.model.comp_layer_changed.connect(self.update_view)
+        self.model.comp_layer_changed.connect(self.failure_check)
         self.model.nodes_changed.connect(self.handle_nodes_changed)
         self.model.attrs_changed.connect(self.handle_attrs_changed)
         self.model.node_moved.connect(self.handle_node_move)
@@ -221,6 +223,14 @@ class StageView(QtWidgets.QGraphicsView):
     def implicit_connections(self):
         if self.model:
             return self.model.implicit_connections
+
+    def failure_check(self, *args):
+        if self.model.comp_layer.failure and not self.main_window.in_startup:
+            info = ('There was a critical error when building the comp.\n'
+                    'Please check your output window for more details as to\n'
+                    'what nodes failed and possibly why.')
+            NxtWarningDialog.show_message('Bad Comp!', info,
+                                          details=self.model.comp_layer.failure)
 
     def update_view(self, dirty=()):
         """Clears and re-draws graphics items. If the dirty list is empty all

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -71,6 +71,7 @@ class USER_PREF():
     FPS = 'fps'
     LOD = 'lod'
     ANIMATION = 'animation'
+    SHOW_DBL_CLICK_MSG = 'show_double_click_message'
 
 
 class EDITOR_CACHE():

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -1,7 +1,7 @@
 {
   "EDITOR": {
     "MAJOR": 3,
-    "MINOR": 7,
+    "MINOR": 8,
     "PATCH": 0
   }
 }


### PR DESCRIPTION
## Additions:
`+` Added preference for hiding "Double Click To Edit" message. See `View > Options > Show Double Click Message`
`+` Added helpful context menu to workflow tools
## Changes:
`*` Bug fix: Right clicking on an implied node would cause an error.
`*` Moved some view options into a sub menu for cleanliness
`*` Bug fix: Attempting to set a hotkey in Python 3 could cause app to crash.
`*` Bug fix: Error icons on nodes would linger after the error was resolved.
`*` Bug fix: Unable to revert instance in some cases.
`*` Bug fix: Broken comps could crash the app on startup/randomly, now a warning is shown when there is a critical comp error. Hopefully this is temporary and these errors can be fully tested out in the future.
`*` Bug fix: Workflow selector items would fail if the user populated the items list via node code.
