### PR TITLE
Fixes for unreal plugin and unreal contexts

### DIFF
--- a/nxt_editor/integration/unreal/Content/Python/init_unreal.py
+++ b/nxt_editor/integration/unreal/Content/Python/init_unreal.py
@@ -80,7 +80,11 @@ def make_or_find_nxt_menu():
     return nxt_menu
 
 def refresh_nxt_menu():
-    nxt_menu = make_or_find_nxt_menu()
+    try:
+        nxt_menu = make_or_find_nxt_menu()
+    except ValueError:
+        # If the plugin is loaded in unreal headless, the menu won't exist.
+        return
     if is_nxt_available():
         nxt_menu.add_menu_entry("nxt-section", make_open_editor_entry())
         nxt_menu.add_menu_entry("nxt-section", make_update_entry())

--- a/nxt_editor/integration/unreal/__init__.py
+++ b/nxt_editor/integration/unreal/__init__.py
@@ -28,7 +28,7 @@ def launch_nxt_in_ue():
         __NXT_WINDOW.show()
         __NXT_WINDOW.raise_()
     else:
-        __NXT_WINDOW = nxt_editor.show_new_editor()
+        __NXT_WINDOW = nxt_editor.show_new_editor(start_rpc=False)
 
     __NXT_WINDOW.close_signal.connect(existing.exit)
     atexit.register(__NXT_WINDOW.close)

--- a/nxt_editor/integration/unreal/__init__.py
+++ b/nxt_editor/integration/unreal/__init__.py
@@ -28,7 +28,7 @@ def launch_nxt_in_ue():
         __NXT_WINDOW.show()
         __NXT_WINDOW.raise_()
     else:
-        __NXT_WINDOW = nxt_editor.show_new_editor(start_rpc=False)
+        __NXT_WINDOW = nxt_editor.show_new_editor()
 
     __NXT_WINDOW.close_signal.connect(existing.exit)
     atexit.register(__NXT_WINDOW.close)


### PR DESCRIPTION
* Fail safely when unreal is loaded headlessly.
* Do not start rpc server in unreal