### PR TITLE
Release editor-v3.8.1

### DIFF
--- a/nxt_editor/connection_graphics_item.py
+++ b/nxt_editor/connection_graphics_item.py
@@ -107,7 +107,8 @@ class AttrConnectionGraphic(QtWidgets.QGraphicsLineItem):
             thick_mult = 1
             pen_style = self.pen_style
         else:
-            painter.setRenderHints(False)
+            painter.setRenderHints(QtGui.QPainter.Antialiasing |
+                                   QtGui.QPainter.SmoothPixmapTransform, False)
             thick_mult = 3
             pen_style = QtCore.Qt.PenStyle.SolidLine
         pen = QtGui.QPen(self.color, self.thickness * thick_mult,

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -288,7 +288,9 @@ class NodeGraphicsItem(graphic_type):
                                    QtGui.QPainter.TextAntialiasing |
                                    QtGui.QPainter.SmoothPixmapTransform)
         else:
-            painter.setRenderHints(False)
+            painter.setRenderHints(QtGui.QPainter.Antialiasing |
+                                   QtGui.QPainter.TextAntialiasing |
+                                   QtGui.QPainter.SmoothPixmapTransform, False)
         self.draw_title(painter, lod)
         self.draw_attributes(painter, lod)
         self.draw_border(painter, lod)
@@ -971,7 +973,9 @@ class NodeGraphicsPlug(QtWidgets.QGraphicsItem):
                                    QtGui.QPainter.TextAntialiasing |
                                    QtGui.QPainter.SmoothPixmapTransform)
         else:
-            painter.setRenderHints(False)
+            painter.setRenderHints(QtGui.QPainter.Antialiasing |
+                                   QtGui.QPainter.TextAntialiasing |
+                                   QtGui.QPainter.SmoothPixmapTransform, False)
         if self.is_hovered:
             painter.setPen(QtGui.QPen(QtCore.Qt.white, self.hover_width, QtCore.Qt.SolidLine, QtCore.Qt.RoundCap, QtCore.Qt.RoundJoin))
         else:

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -2,6 +2,6 @@
   "EDITOR": {
     "MAJOR": 3,
     "MINOR": 8,
-    "PATCH": 0
+    "PATCH": 1
   }
 }


### PR DESCRIPTION
## Changes:
`*` Bug fix, in older version of Qt node graphic LODs could crash the app.

Fixes #177 