### PR TITLE
Connection graphic patch

### DIFF
--- a/nxt_editor/connection_graphics_item.py
+++ b/nxt_editor/connection_graphics_item.py
@@ -111,8 +111,7 @@ class AttrConnectionGraphic(QtWidgets.QGraphicsLineItem):
                                    QtGui.QPainter.SmoothPixmapTransform, False)
             thick_mult = 3
             pen_style = QtCore.Qt.PenStyle.SolidLine
-        pen = QtGui.QPen(self.color, self.thickness * thick_mult,
-                         self.pen_style)
+        pen = QtGui.QPen(self.color, self.thickness * thick_mult, pen_style)
         # if self.tgt_path in self.model.selection:
         #    pen.setColor(colors.SELECTED)
         # elif self.is_hovered:

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -1,6 +1,7 @@
 # Built-in
 import textwrap
 import sys
+import logging
 from functools import partial
 
 # External
@@ -18,7 +19,7 @@ from nxt_editor import user_dir
 from nxt_editor.dockwidgets.dock_widget_base import DockWidgetBase
 from nxt_editor.pixmap_button import PixmapButton
 from nxt_editor.label_edit import LabelEdit
-from nxt_editor import colors
+from nxt_editor import colors, LOGGER_NAME
 from nxt_editor.decorator_widgets import OpinionDots
 from nxt import DATA_STATE, NODE_ERRORS, nxt_path
 from nxt.nxt_node import INTERNAL_ATTRS, META_ATTRS
@@ -26,6 +27,8 @@ from nxt import tokens
 
 # Fixme: Should this be a pref?
 HISTORICAL_MAX_CHARS = 50
+
+logger = logging.getLogger(LOGGER_NAME)
 
 
 class PropertyEditor(DockWidgetBase):
@@ -1250,7 +1253,11 @@ class PropertyModel(QtCore.QAbstractTableModel):
             if self.state:
                 if sys.version_info[0] > 2 and isinstance(self.state, str):
                     self.state = bytes(self.state, 'utf-8')
-                self.horizontal_header.restoreState(self.state)
+                try:
+                    self.horizontal_header.restoreState(self.state)
+                except TypeError:
+                    logger.error('Corrupted property editor pref!')
+                    self.state = ''
             self.view.resizeColumnToContents(COLUMNS.nxt_type)
 
     def get_data(self):

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -1258,11 +1258,11 @@ class StageView(QtWidgets.QGraphicsView):
                 graphic.update_collapse()
             collapsed = self.model.get_node_collapse(path, comp_layer)
             if collapsed:
-                children = self.model.get_children(path,
-                                                   include_implied=True)
-                for child_path in children:
+                descendants = self.model.get_descendants(path,
+                                                         include_implied=True)
+                for child_path in descendants:
                     self.remove_node_graphic(child_path)
-                if children:
+                if descendants:
                     roots_hit.add(nxt_path.get_root_path(path))
             else:
                 descendants = self.model.get_descendants(path,


### PR DESCRIPTION
`*` Bug fix: Corrupted editor cache could crash the editor when selecting a node.
`*` Bug fix: Connection graphic lines wouldn't go away after collapsing some nodes.

Fix for this visual bug: 
![image](https://user-images.githubusercontent.com/54835354/112900228-2e941580-90b1-11eb-85bc-a5a3c31baeb4.png)
