### PR TITLE
Show dialog for failed opening.

### DIFF
--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -516,13 +516,11 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             new_stage = self.nxt.load_file(potential_path)
         except IOError as e:
-            # Log error if no file could be loaded and set a blank stage
-            new_stage = None
-            logger.exception("Nxt failed to open file from path, see log.")
+            NxtWarningDialog.show_message("Failed to Open", str(e))
         self.set_waiting_cursor(False)
         if new_stage:
             self.new_tab(initial_stage=new_stage, update=not self.in_startup)
-        user_dir.editor_cache[user_dir.USER_PREF.LAST_OPEN] = potential_path
+            user_dir.editor_cache[user_dir.USER_PREF.LAST_OPEN] = potential_path
 
     def save_open_tab(self):
         """Save the file that corresponds to the currently selected tab."""


### PR DESCRIPTION
[Next version of core](https://github.com/nxt-dev/nxt/pull/83) will error when asked to load a file that doesn't exist, handle that error case gracefully. 
![image](https://user-images.githubusercontent.com/11843596/120402974-530aa900-c311-11eb-8287-20f969665535.png)
