### PR TITLE
Release editor-v3.9.0

### DIFF
--- a/build/validate_version_numbers.nxt
+++ b/build/validate_version_numbers.nxt
@@ -162,7 +162,7 @@
                 "for rel_cat, rel_dict in version_data.items():",
                 "    actual = rel_dict['actual']",
                 "    release = rel_dict['version']",
-                "    print release",
+                "    print(release)",
                 "    rel_type = rel_dict['rel_type']",
                 "    if rel_type is None:",
                 "        continue",

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -516,13 +516,11 @@ class MainWindow(QtWidgets.QMainWindow):
         try:
             new_stage = self.nxt.load_file(potential_path)
         except IOError as e:
-            # Log error if no file could be loaded and set a blank stage
-            new_stage = None
-            logger.exception("Nxt failed to open file from path, see log.")
+            NxtWarningDialog.show_message("Failed to Open", str(e))
         self.set_waiting_cursor(False)
         if new_stage:
             self.new_tab(initial_stage=new_stage, update=not self.in_startup)
-        user_dir.editor_cache[user_dir.USER_PREF.LAST_OPEN] = potential_path
+            user_dir.editor_cache[user_dir.USER_PREF.LAST_OPEN] = potential_path
 
     def save_open_tab(self):
         """Save the file that corresponds to the currently selected tab."""

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -1,7 +1,7 @@
 {
   "EDITOR": {
     "MAJOR": 3,
-    "MINOR": 8,
-    "PATCH": 3
+    "MINOR": 9,
+    "PATCH": 0
   }
 }


### PR DESCRIPTION
## Changes:
`*` Show dialog for failed opening.
