### PR TITLE
User UX requests

### DIFF
--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -1777,6 +1777,17 @@ class CodeEditorActions(NxtActionContainer):
                                         True)
         self.overlay_message_action.setChecked(state)
 
+        self.show_data_state_action = NxtAction('Code Editor Data State Overlay',
+                                                parent=self)
+        self.show_data_state_action.setWhatsThis('When on this pref will enable a simple HUD on the top right of '
+                                                 'the code editor. The HUD will update to display the current data '
+                                                 'state (raw, resolved, cached).')
+        self.show_data_state_action.setAutoRepeat(False)
+        self.show_data_state_action.setCheckable(True)
+        state = user_dir.user_prefs.get(user_dir.USER_PREF.SHOW_CE_DATA_STATE,
+                                        True)
+        self.show_data_state_action.setChecked(state)
+
         def toggle_dbl_click_msg():
             new = self.overlay_message_action.isChecked()
             user_dir.user_prefs[user_dir.USER_PREF.SHOW_DBL_CLICK_MSG] = new
@@ -1790,6 +1801,7 @@ class CodeEditorActions(NxtActionContainer):
                                      self.font_bigger, self.font_smaller,
                                      self.font_size_revert,
                                      self.overlay_message_action,
+                                     self.show_data_state_action,
                                      self.new_line, self.indent_line,
                                      self.unindent_line,
                                      self.run_line_global_action,

--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -375,6 +375,19 @@ class AppActions(NxtActionContainer):
         self.find_and_open_action.setShortcutContext(context)
         self.available_without_model.append(self.find_and_open_action)
 
+        def clear_logs():
+            rich = self.main_window.output_log.rich_output_textedit
+            raw = self.main_window.output_log.raw_output_textedit
+            rich.clear()
+            raw.clear()
+
+        self.clear_logs_action = NxtAction(text='Clear All Logs',
+                                           parent=self)
+        self.clear_logs_action.setWhatsThis('Clear all the text from all of the output logs (raw and rich).')
+        self.clear_logs_action.triggered.connect(clear_logs)
+        self.clear_logs_action.setShortcutContext(context)
+        self.available_without_model.append(self.clear_logs_action)
+
         self.action_display_order = [self.find_node_action,
                                      self.new_graph_action,
                                      self.open_file_action, self.undo_action,
@@ -387,6 +400,7 @@ class AppActions(NxtActionContainer):
                                      self.output_log_action,
                                      self.hotkey_editor_action,
                                      self.workflow_tools_action,
+                                     self.clear_logs_action,
                                      self.close_action]
 
 

--- a/nxt_editor/dockwidgets/code_editor.py
+++ b/nxt_editor/dockwidgets/code_editor.py
@@ -1295,11 +1295,13 @@ class OverlayWidget(QtWidgets.QWidget):
         model = code_editor.stage_model
         self.data_state = code_editor.actual_display_state
         painter.setPen(QtCore.Qt.white)
-        # Draw top right data state text
-        offset = font_metrics.boundingRect(self.data_state).width()
-        offset += painter.font().pointSize() * 1.5
-        painter.drawText(self.rect().right() - offset,
-                         painter.font().pointSize() * 1.5, self.data_state)
+        # Draw top right data state text to HUD
+        show_data_state = self._parent.ce_actions.show_data_state_action.isChecked()
+        if show_data_state:
+            offset = font_metrics.boundingRect(self.data_state).width()
+            offset += painter.font().pointSize() * 1.5
+            painter.drawText(self.rect().right() - offset,
+                             painter.font().pointSize() * 1.5, self.data_state)
         # Draw center message text
         show_msg = self._parent.ce_actions.overlay_message_action.isChecked()
         if show_msg:

--- a/nxt_editor/dockwidgets/output_log.py
+++ b/nxt_editor/dockwidgets/output_log.py
@@ -200,13 +200,13 @@ class OutputLog(DockWidgetBase):
         # Rich Output
         self.rich_output_textedit = OutputTextBrowser(self)
         self.log_filter_button = LogFilterButton()
-        self.clear_button = QtWidgets.QPushButton('Clear Log')
-        self.clear_button.pressed.connect(self.rich_output_textedit.clear)
+        self.clear_rich_button = QtWidgets.QPushButton('Clear Log')
+        self.clear_rich_button.pressed.connect(self.rich_output_textedit.clear)
 
         self.buttons_layout = QtWidgets.QHBoxLayout()
         self.buttons_layout.addWidget(self.log_filter_button)
         self.buttons_layout.addStretch(stretch=1)
-        self.buttons_layout.addWidget(self.clear_button)
+        self.buttons_layout.addWidget(self.clear_rich_button)
 
         self.rich_output_layout = QtWidgets.QVBoxLayout()
         self.rich_output_layout.setContentsMargins(0, 0, 0, 0)
@@ -224,6 +224,9 @@ class OutputLog(DockWidgetBase):
         self.python_layout = QtWidgets.QHBoxLayout()
         self.python_layout.addWidget(QtWidgets.QLabel("Python: "))
         self.python_layout.addWidget(self.python_edit, stretch=1)
+        self.clear_raw_button = QtWidgets.QPushButton('Clear Log')
+        self.clear_raw_button.pressed.connect(self.raw_output_textedit.clear)
+        self.python_layout.addWidget(self.clear_raw_button)
 
         self.raw_output_layout = QtWidgets.QVBoxLayout()
         self.raw_output_layout.setContentsMargins(0, 0, 0, 0)
@@ -423,19 +426,22 @@ class OutputLog(DockWidgetBase):
 class OutputTextEdit(QtWidgets.QTextEdit):
     def __init__(self, parent):
         super(OutputTextEdit, self).__init__(parent=parent)
+        self._parent = parent
         self.setStyleSheet(self.parent().parent().styleSheet())
         self.setReadOnly(True)
         self.setFont(QtGui.QFont('Roboto Mono', 10))
 
     def contextMenuEvent(self, event):
         menu = self.createStandardContextMenu()
-        menu.addAction('Clear All', self.clear)
+        menu.addAction('Clear', self.clear)
+        menu.addAction(self._parent.parent().app_actions.clear_logs_action)
         menu.exec_(event.globalPos())
 
 
 class OutputTextBrowser(QtWidgets.QTextBrowser):
     def __init__(self, parent):
         super(OutputTextBrowser, self).__init__(parent=parent)
+        self._parent = parent
         self.anchorClicked.connect(self.parent().link_clicked)
         self.setStyleSheet(self.parent().parent().styleSheet())
         self.setOpenLinks(False)
@@ -443,7 +449,8 @@ class OutputTextBrowser(QtWidgets.QTextBrowser):
 
     def contextMenuEvent(self, event):
         menu = self.createStandardContextMenu()
-        menu.addAction('Clear All', self.clear)
+        menu.addAction('Clear', self.clear)
+        menu.addAction(self._parent.parent().app_actions.clear_logs_action)
         menu.exec_(event.globalPos())
 
 

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -72,6 +72,7 @@ class USER_PREF():
     LOD = 'lod'
     ANIMATION = 'animation'
     SHOW_DBL_CLICK_MSG = 'show_double_click_message'
+    SHOW_CE_DATA_STATE = 'show_code_editor_data_state'
 
 
 class EDITOR_CACHE():


### PR DESCRIPTION
`+` New user pref `show_code_editor_data_state`, when `False` the data state will not be shown in the top right of the code editor. Set it in your `prefs.json` or setup a hotkey in the hotkey editor (under code editor).
`+` New action to clear all the log widgets. Available in the context menu of the output window and hotkey editor.