### PR TITLE
Bug fix: Prevent exec cycles in model

### DIFF
--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -1984,6 +1984,10 @@ class StageModel(QtCore.QObject):
         if source_node_path == nxt_path.WORLD:
             logger.error("Cannot set node exec in to the world")
             return
+        if source_node_path in self.get_exec_order(node_path):
+            logger.error('Cannot connect exec in from {} (would cycle)'.format(source_node_path),
+                         links=[source_node_path])
+            return
         layer_path = self.get_layer_path(layer, fallback=LAYERS.TARGET)
         node_ns = nxt_path.str_path_to_node_namespace(node_path)
         if len(node_ns) > 1:

--- a/nxt_editor/test/test_stage_model.py
+++ b/nxt_editor/test/test_stage_model.py
@@ -75,3 +75,24 @@ class NodeInstanceAttributes(unittest.TestCase):
         self.assertEqual(child_expected_local, child_locals)
         self.assertEqual(child_expected_inherit, child_inherit)
         self.assertEqual(child_expected_inst, child_inst)
+
+
+class ExecOrderCycle(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        os.chdir(os.path.dirname(__file__))
+        cls.stage = Session().load_file(filepath="StageInstanceTest.nxt")
+        cls.model = stage_model.StageModel(cls.stage)
+        cls.comp_layer = cls.model.comp_layer
+
+    def test_local_node_attrs(self):
+        node_path1 = '/inst_source4'
+        node_path2 = '/inst_target4'
+        print("Testing that {} has no exec in set".format(node_path1))
+        node1_exec_in = self.model.get_node_exec_in(node_path1)
+        self.assertIsNone(node1_exec_in)
+        print("Testing that {} can't have its exec in set to {}".format(node_path1, node_path2))
+        self.model.set_node_exec_in(node_path1, node_path2)
+        node1_exec_in = self.model.get_node_exec_in(node_path1)
+        self.assertIsNone(node1_exec_in)


### PR DESCRIPTION
`*` Bug fix: Prevent exec cycles when setting node exec in
`...` Added unittest for exec cycle
fixes #198