### PR TITLE
Layer lock patches

### DIFF
--- a/nxt_editor/dockwidgets/layer_manager.py
+++ b/nxt_editor/dockwidgets/layer_manager.py
@@ -124,8 +124,6 @@ class LayerTreeView(QtWidgets.QTreeView):
             return
         layer = clicked_idx.internalPointer()
         layer_path = self.model().stage_model.get_layer_path(layer)
-        if self.model().stage_model.get_layer_locked(layer_path):
-            return
         self.model().stage_model.set_target_layer(layer_path)
 
     def on_item_dbl_clicked(self, clicked_idx):

--- a/nxt_editor/dockwidgets/property_editor.py
+++ b/nxt_editor/dockwidgets/property_editor.py
@@ -527,7 +527,7 @@ class PropertyEditor(DockWidgetBase):
         self.properties_frame.hide()
 
     def handle_locking(self, *args):
-        self.locked = self.stage_model.get_node_locked(self.node_path)
+        self.locked = self.stage_model.target_layer.get_locked()
         if self.locked:
             self.table_view.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
         else:


### PR DESCRIPTION
`*` When target layer locks, set target to TOP layer - resets on undo.
`...` More warnings and dings.
`...` Allow edits to be made on locked node paths, so long as the target layer isn't locked. Will result in a localized node on the target layer.