### PR TITLE
QApp bug when restarting NXT in interpreter session 

### DIFF
--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -82,11 +82,16 @@ except ImportError:
 
 
 def _new_qapp():
-    app = QtWidgets.QApplication
+    app = QtWidgets.QApplication.instance()
+    create_new = False
+    if not app:
+        app = QtWidgets.QApplication
+        app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+        create_new = True
     os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
-    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
-    app = app(sys.argv)
+    if create_new:
+        app = app(sys.argv)
     style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
     style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
     stream = QtCore.QTextStream(style_file)

--- a/nxt_editor/integration/__init__.py
+++ b/nxt_editor/integration/__init__.py
@@ -3,23 +3,11 @@ import sys
 import subprocess
 import importlib
 
-import bpy
-
-b_major, b_minor, b_patch = bpy.app.version
-
 
 class NxtIntegration(object):
 
     def __init__(self, name):
         self.name = name
-
-    @staticmethod
-    def show_message(message, title, icon='INFO'):
-
-        def draw(self, *args):
-            self.layout.label(text=message)
-
-        bpy.context.window_manager.popup_menu(draw, title=title, icon=icon)
 
     @classmethod
     def setup(cls):
@@ -61,18 +49,11 @@ class NxtIntegration(object):
             global_name = module_name
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
-        pkg = 'nxt-editor'
-        if b_major == 2:
-            exe = bpy.app.binary_path_python
-        else:
-            exe = sys.executable
-        subprocess.run([exe, "-m", "pip", "install", pkg],
-                       check=True, env=environ_copy)
+        subprocess.run([sys.executable, "-m", "pip", "install",
+                        package_name], check=True, env=environ_copy)
+
         success = self._safe_import_package(package_name=package_name,
                                             global_name=global_name)
-        NxtIntegration.show_message('NXT package Installed! '
-                                    'You may need to restart Blender.',
-                                    'Success!')
         return success
 
     @staticmethod
@@ -85,14 +66,9 @@ class NxtIntegration(object):
         """
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
-        if b_major == 2:
-            exe = bpy.app.binary_path_python
-        else:
-            exe = sys.executable
-        subprocess.run([exe, "-m", "pip", "install", "-U",
+        subprocess.run([sys.executable, "-m", "pip", "install", "-U",
                         package_name], check=True, env=environ_copy)
-        NxtIntegration.show_message('NXT package updated! '
-                                    'Please restart Blender.', 'Success!')
+        print('Please restart your DCC or Python interpreter')
 
     def check_for_nxt_core(self, install=False):
         has_core = self._safe_import_package('nxt')
@@ -103,8 +79,7 @@ class NxtIntegration(object):
         success = self._install_and_import_package('nxt',
                                                    package_name='nxt-core')
         if not success:
-            NxtIntegration.show_message('Failed to import and/or install '
-                                        'nxt-editor.', 'Failed!')
+            print('Failed to import and/or install nxt-core')
         return success
 
     def check_for_nxt_editor(self, install=False):
@@ -116,8 +91,7 @@ class NxtIntegration(object):
         success = self._install_and_import_package('nxt_editor',
                                                    package_name='nxt-editor')
         if not success:
-            NxtIntegration.show_message('Failed to import and/or install '
-                                        'nxt-editor.', 'Failed!')
+            print('Failed to import and/or install nxt-editor')
         return success
 
     def update(self):
@@ -137,11 +111,7 @@ class NxtIntegration(object):
         """
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
-        if b_major == 2:
-            exe = bpy.app.binary_path_python
-        else:
-            exe = sys.executable
-        subprocess.run([exe, "-m", "pip", "uninstall",
+        subprocess.run([sys.executable, "-m", "pip", "uninstall",
                         package_name, '-y'], check=True, env=environ_copy)
 
     def uninstall(self):
@@ -149,9 +119,7 @@ class NxtIntegration(object):
             self._uninstall_package('nxt-core')
         if self.check_for_nxt_editor():
             self._uninstall_package('nxt-editor')
-        NxtIntegration.show_message('NXT was uninstalled, sorry '
-                                    'to see you go.', 'Uninstalled!')
-        # print('Please restart your DCC or Python interpreter')
+        print('Please restart your DCC or Python interpreter')
 
     def launch_nxt(self):
         raise NotImplementedError('Your DCC needs it own nxt launch method.')

--- a/nxt_editor/integration/blender/README.md
+++ b/nxt_editor/integration/blender/README.md
@@ -1,6 +1,8 @@
 # Installation
-**This is an experimental version of nxt_blender. Save early, save often.**  
+**This is an experimental version of nxt_blender. Save early, save often.**   
 This is a Blender addon for nxt. Note that it will access the internet to install.  
+Please read all the steps below before starting.
+
 _In some of our testing we found that we needed to install Python on 
 the system inorder for Blender to be able to open the NXT editor. If you 
 get strange import errors when you try to import `nxt_editor`, try 
@@ -9,7 +11,7 @@ installing Python (same version as Blender's) on your machine._
 ### By hand (if you're familiar with pip)
 1. Locate the path to blenders Python interpreter
     - In Blender, you can run `sys.exec_prefix` to find the folder containing the Python executable
-2. Open Terminal or CMD (If you're using Windows)
+2. Open Terminal, CMD, ect. - Must have elevated permissions
 3. Run: `/path/to/blender/python.exe -m pip install nxt-editor`
 4. Start Blender
 5. Open the addon manager (Edit > Preferences > Add-ons)
@@ -18,19 +20,21 @@ installing Python (same version as Blender's) on your machine._
 
 
 ### Automated
-1. Open the addon manager (Edit > Preferences > Add-ons)
-2. Click "Install" and select the `nxt_blender.py` file provided with this addon zip
-3. Enable the `NXT Blender` and twirl down the addon preferences
-3. Click `Install NXT dependencies`
-   - The installation may take a minute or two, during this time Blender will be unresponsive
-   - Optionally open the console window before running the script, so you can see what's happening
-4. Restart Blender
+1. Launch Blender with elevated permissions
+2. Open the addon manager (Edit > Preferences > Add-ons)
+3. Click "Install" and select the `nxt_blender.py` file provided with this addon zip
+4. Enable the `NXT Blender` and twirl down the addon preferences
+5. Click `Install NXT dependencies`
+   - It is recommended to open the console window before running the script, so you can see what's happening. Window > Toggle System Console.
+   - The installation may take a minute or two, during this time Blender will be unresponsive.
+6. Restart Blender
  
 # Usage
 - Ensure the `NXT Blender` addon is enabled
 - To launch NXT navigate the newly created `NXT` menu and select `Open Editor`
 
 # Updating
+_These steps also require elevated permissions for Blender or the terminal._
 ### By hand (if you're familiar with pip)
 1. In terminal or cmd run: `/path/to/blender/python.exe -m pip install -U nxt-editor nxt`
 2. Restart Blender
@@ -48,6 +52,7 @@ _or_
 3. Restart Blender
 
 # Uninstall
+_These steps also require elevated permissions for Blender or the terminal._
 ### By hand (if you're familiar with pip)
 1. Open the addon manager (Edit > Preferences > Add-ons)
 2. Locate the `NXT Blender` and twirl down the addon preferences

--- a/nxt_editor/integration/blender/__init__.py
+++ b/nxt_editor/integration/blender/__init__.py
@@ -1,8 +1,9 @@
 # Builtin
+import atexit
 import os
 import shutil
+import subprocess
 import sys
-import atexit
 
 # External
 import bpy
@@ -14,6 +15,7 @@ from nxt_editor.integration import NxtIntegration
 import nxt_editor
 
 __NXT_INTEGRATION__ = None
+b_major, b_minor, b_patch = bpy.app.version
 
 
 class Blender(NxtIntegration):
@@ -26,10 +28,19 @@ class Blender(NxtIntegration):
         if b_major == 2:
             addons_dir = bpy.utils.user_resource('SCRIPTS', 'addons')
         else:
-            addons_dir = os.path.join(bpy.utils.user_resource('SCRIPTS'), '/addons')
+            addons_dir = os.path.join(bpy.utils.user_resource('SCRIPTS'),
+                                      '/addons')
         self.addons_dir = addons_dir.replace(os.sep, '/')
         self.instance = None
         self.nxt_qapp = QtWidgets.QApplication.instance()
+
+    @staticmethod
+    def show_message(message, title, icon='INFO'):
+
+        def draw(self, *args):
+            self.layout.label(text=message)
+
+        bpy.context.window_manager.popup_menu(draw, title=title, icon=icon)
 
     @classmethod
     def setup(cls):
@@ -38,6 +49,58 @@ class Blender(NxtIntegration):
         integration_filepath = self.get_integration_filepath()
         shutil.copy(integration_filepath, self.addons_dir)
         bpy.ops.preferences.addon_enable(module='nxt_' + self.name)
+
+    def _install_and_import_package(self, module_name, package_name=None,
+                                    global_name=None):
+        """Calls a subprocess to pip install the given package name and then
+        attempts to import the new package.
+
+        :param module_name: Desired module to import after install
+        :param package_name: pip package name
+        :param global_name: Global name to access the module if different
+        than the module name.
+        :raises: subprocess.CalledProcessError
+        :return: bool
+        """
+        if package_name is None:
+            package_name = module_name
+        if global_name is None:
+            global_name = module_name
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        pkg = 'nxt-editor'
+        if b_major == 2:
+            exe = bpy.app.binary_path_python
+        else:
+            exe = sys.executable
+        print('INSTLALING: ' + pkg)
+        subprocess.run([exe, "-m", "pip", "install", pkg],
+                       check=True, env=environ_copy)
+        success = self._safe_import_package(package_name=package_name,
+                                            global_name=global_name)
+        Blender.show_message('NXT package Installed! '
+                             'You may need to restart Blender.',
+                             'Success!')
+        return success
+
+    @staticmethod
+    def _update_package(package_name):
+        """Calls a subprocess to pip update the given package name.
+
+        :param package_name: pip package name
+        :raises: subprocess.CalledProcessError
+        :return: None
+        """
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        if b_major == 2:
+            exe = bpy.app.binary_path_python
+        else:
+            exe = sys.executable
+        subprocess.run([exe, "-m", "pip", "install", "-U",
+                        package_name], check=True, env=environ_copy)
+        Blender.show_message('NXT package updated! '
+                             'Please restart Blender.', 'Success!')
 
     @classmethod
     def update(cls):
@@ -50,13 +113,13 @@ class Blender(NxtIntegration):
 
     @classmethod
     def launch_nxt(cls):
-        self = cls()
-        os.environ[NXT_DCC_ENV_VAR] = 'blender'
         global __NXT_INTEGRATION__
-        if not __NXT_INTEGRATION__:
-            __NXT_INTEGRATION__ = self
-        else:
+        if __NXT_INTEGRATION__:
             self = __NXT_INTEGRATION__
+        else:
+            self = cls()
+            __NXT_INTEGRATION__ = self
+        os.environ[NXT_DCC_ENV_VAR] = 'blender'
         if self.instance:
             self.instance.show()
             return
@@ -71,20 +134,19 @@ class Blender(NxtIntegration):
 
         def unregister_nxt():
             self.instance = None
-            if self.nxt_qapp:
-                self.nxt_qapp.quit()
-                self.nxt_qapp = None
 
         nxt_win.close_signal.connect(unregister_nxt)
         nxt_win.show()
+        # Forces keyboard focus
+        nxt_win.activateWindow()
         atexit.register(nxt_win.close)
         self.instance = nxt_win
         return self
 
     def quit_nxt(self):
         if self.instance:
-            self.instance.close()
             atexit.unregister(self.instance.close)
+            self.instance.close()
         if self.nxt_qapp:
             self.nxt_qapp.quit()
         global __NXT_INTEGRATION__
@@ -97,3 +159,32 @@ class Blender(NxtIntegration):
                                             interpreter_exe=bpy.app.binary_path,
                                             exe_script_args=args)
 
+    def check_for_nxt_core(self, install=False):
+        success = super(Blender, self).check_for_nxt_core(install=install)
+        if not success:
+            Blender.show_message('Failed to import and/or install '
+                                 'nxt-editor.', 'Failed!')
+        return success
+
+    @staticmethod
+    def _uninstall_package(package_name):
+        """Calls a subprocess to pip uninstall the given package name. Will
+        NOT prompt the user to confrim uninstall.
+
+        :param package_name: pip package name
+        :raises: subprocess.CalledProcessError
+        :return: None
+        """
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        if b_major == 2:
+            exe = bpy.app.binary_path_python
+        else:
+            exe = sys.executable
+        subprocess.run([exe, "-m", "pip", "uninstall",
+                        package_name, '-y'], check=True, env=environ_copy)
+
+    def uninstall(self):
+        super(Blender, self).uninstall()
+        Blender.show_message('NXT was uninstalled, sorry '
+                             'to see you go.', 'Uninstalled!')


### PR DESCRIPTION
`*` Bug fix: It was not possible to close and reopen NXT in Blender because we did not take proper care of the fact that a `qapp` had already been started in the current interpreter session.
`...` Added some extra classification to the Blender readme.