### PR TITLE
Rich output fix

### DIFF
--- a/nxt_editor/dockwidgets/output_log.py
+++ b/nxt_editor/dockwidgets/output_log.py
@@ -334,7 +334,9 @@ class OutputLog(DockWidgetBase):
                 curr_rt_layer.cache_layer.was_during_node_exec(msg_time)):
             return
         if self.log_filter_button.is_level_enabled(nxt_log.NODEOUT):
-            self.write_rich_output(val.replace('<', '&lt;'), raw=True)
+            # Intentionally breaking html syntax here. Printing type(object)
+            # was being interpreted as html. <class 'type'>
+            self.write_rich_output(val.replace('<', '&lt;'))
 
     def _write_raw_output(self, val):
         """Write text to the raw output textedit. Dose NOT write to the rich
@@ -353,7 +355,7 @@ class OutputLog(DockWidgetBase):
         else:
             self.raw_output_textedit.verticalScrollBar().setValue(cur)
 
-    def write_rich_output(self, val, level=None, raw=False):
+    def write_rich_output(self, val, level=None):
         """Neighbor to write_raw_output. Use of write as naming is specific,
         no newlines created from thin air, must come form input.
 

--- a/nxt_editor/dockwidgets/output_log.py
+++ b/nxt_editor/dockwidgets/output_log.py
@@ -334,7 +334,7 @@ class OutputLog(DockWidgetBase):
                 curr_rt_layer.cache_layer.was_during_node_exec(msg_time)):
             return
         if self.log_filter_button.is_level_enabled(nxt_log.NODEOUT):
-            self.write_rich_output(val)
+            self.write_rich_output(val.replace('<', '&lt;'), raw=True)
 
     def _write_raw_output(self, val):
         """Write text to the raw output textedit. Dose NOT write to the rich
@@ -353,7 +353,7 @@ class OutputLog(DockWidgetBase):
         else:
             self.raw_output_textedit.verticalScrollBar().setValue(cur)
 
-    def write_rich_output(self, val, level=None):
+    def write_rich_output(self, val, level=None, raw=False):
         """Neighbor to write_raw_output. Use of write as naming is specific,
         no newlines created from thin air, must come form input.
 


### PR DESCRIPTION
`*` Node output is more reliably rendered in the rich output log.

---
Probably doesn't fix every edge case, but it solves the issue where printing the `type` of an object would print a blank line in the rich output window.