### PR TITLE
Release editor-v3.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,10 @@ branches:
 python:
   - "3.7"
 
-services:
-    - xvfb
-
-env:
-    - QT_CI_PACKAGES=qt.qt5.5132.gcc_64,qt.qt5.5132.qtwebengine PATH="$TRAVIS_BUILD_DIR/Qt/5.13.2/gcc_64/bin:${PATH}"
-
 before_install:
   - |
     if [ "$TRAVIS_BRANCH" = "dev" ] && [ "$TRAVIS_EVENT_TYPE" = "push" ]; then
-        echo "Push to dev, not running tests until PR"
+        echo "Push to dev, not running until push to release"
         exit 0
     else
       echo "Doing the build"
@@ -26,18 +20,11 @@ install:
   - git clone https://github.com/nxt-dev/nxt.git
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
-  - pip install twine
-  - sudo apt-get install -y libxkbcommon-x11-0
-  - sudo apt-get install -y libgl1-mesa-dev
 
 script:
   - |
-    if [ "$TRAVIS_BRANCH" = "release" ] && [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
-          python -m nxt.cli test
-          exit $?
-    fi
-  - |
     if [ "$TRAVIS_BRANCH" = "release" ] && [ "$TRAVIS_EVENT_TYPE" = "push" ]; then
+          pip install twine
           python -m nxt.cli exec nxt_editor/build/packaging.nxt -s /make_and_upload
           exit $?
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,17 @@ before_install:
     fi
 
 install:
+  - export QT_DEBUG_PLUGINS=1
   - cd ..
   - git clone https://github.com/nxt-dev/nxt.git
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
   - pip install twine
-  - sudo apt-get install -qq libegl1-mesa
+  - sudo apt install libxcb-image0
+  - sudo apt install libxcb-keysyms1
+  - sudo apt install libxcb-render-util0
+  - sudo apt install libxcb-xkb1
+  - sudo apt install libxkbcommon-x11-0
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ before_install:
 install:
   - cd ..
   - git clone https://github.com/nxt-dev/nxt.git
-  - pip install ./nxt_editor
   - pip install importlib-metadata==3.4
+  - pip install ./nxt_editor
   - pip install twine
   - sudo apt-get install -y libxkbcommon-x11-0
   - sudo apt-get install -y libgl1-mesa-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ install:
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
   - pip install twine
-  - sudo apt-get install -y libxkbcommon-x11-0
+  - sudo apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev
+  - sudo apt-get install libxkbcommon-x11-dev
   - sudo apt-get install -y libgl1-mesa-dev
-  - sudo apt-get install -y libxcb-xinerama0
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
   - pip install twine
+  - sudo apt-get install -qq libegl1-mesa
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
   - pip install twine
-  - sudo apt install libxkbcommon-x11-0
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ branches:
 python:
   - "3.7"
 
-services:
-    - xvfb
-
-env:
-    - QT_CI_PACKAGES=qt.qt5.5132.gcc_64,qt.qt5.5132.qtwebengine PATH="$TRAVIS_BUILD_DIR/Qt/5.13.2/gcc_64/bin:${PATH}"
-
 before_install:
   - |
     if [ "$TRAVIS_BRANCH" = "dev" ] && [ "$TRAVIS_EVENT_TYPE" = "push" ]; then
@@ -27,9 +21,6 @@ install:
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
   - pip install twine
-  - sudo apt-get install libxcb-randr0-dev libxcb-xtest0-dev libxcb-xinerama0-dev libxcb-shape0-dev libxcb-xkb-dev
-  - sudo apt-get install libxkbcommon-x11-dev
-  - sudo apt-get install -y libgl1-mesa-dev
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
   - pip install twine
+  - sudo apt-get install libxcb-xinerama0
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - pip install twine
   - sudo apt-get install -y libxkbcommon-x11-0
   - sudo apt-get install -y libgl1-mesa-dev
+  - sudo apt-get install -y libxcb-xinerama0
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,12 @@ install:
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
   - pip install twine
-  - sudo apt install libxcb-image0
-  - sudo apt install libxcb-keysyms1
-  - sudo apt install libxcb-render-util0
-  - sudo apt install libxcb-xkb1
   - sudo apt install libxkbcommon-x11-0
 
 script:
   - |
     if [ "$TRAVIS_BRANCH" = "release" ] && [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
+          ldd /opt/XnView/lib/platforms/libqxcb.so  | grep "not found"
           python -m nxt.cli test
           exit $?
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,12 @@ branches:
 python:
   - "3.7"
 
+services:
+    - xvfb
+
+env:
+    - QT_CI_PACKAGES=qt.qt5.5132.gcc_64,qt.qt5.5132.qtwebengine PATH="$TRAVIS_BUILD_DIR/Qt/5.13.2/gcc_64/bin:${PATH}"
+
 before_install:
   - |
     if [ "$TRAVIS_BRANCH" = "dev" ] && [ "$TRAVIS_EVENT_TYPE" = "push" ]; then
@@ -21,18 +27,18 @@ install:
   - git clone https://github.com/nxt-dev/nxt.git
   - pip install importlib-metadata==3.4
   - pip install ./nxt_editor
-  - pip install twine
-  - sudo apt-get install libxcb-xinerama0
+  - sudo apt-get install -y libxkbcommon-x11-0
+  - sudo apt-get install -y libgl1-mesa-dev
 
 script:
   - |
     if [ "$TRAVIS_BRANCH" = "release" ] && [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
-          ldd /opt/XnView/lib/platforms/libqxcb.so  | grep "not found"
           python -m nxt.cli test
           exit $?
     fi
   - |
     if [ "$TRAVIS_BRANCH" = "release" ] && [ "$TRAVIS_EVENT_TYPE" = "push" ]; then
+          pip install twine
           python -m nxt.cli exec nxt_editor/build/packaging.nxt -s /make_and_upload
           exit $?
     fi

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -66,10 +66,13 @@ def make_resources(qrc_path=None, result_path=None):
         return
 
     try:
-        subprocess.check_call(['rcc', '-g', 'python', qrc_path, result_path])
+        subprocess.check_call(['rcc', '-g', 'python', qrc_path,
+                               '-o', result_path])
     except:
-        raise Exception("Cannot find pyside2 rcc to generate UI resources."
-                        " Reinstalling pyside2 may fix the problem.")
+        raise Exception("Failed to generate UI resources using pyside2 rcc!"
+                        " Reinstalling pyside2 may fix the problem. If you "
+                        "know how to use rcc please build from: \"{}\" and "
+                        "output to \"{}\"".format(qrc_path, result_path))
     else:
         return
 

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -67,7 +67,7 @@ def make_resources(qrc_path=None, result_path=None):
 
     try:
         subprocess.check_call(['rcc', '-g', 'python', qrc_path,
-                               '-o', result_path])
+                               '-o', result_path], cwd=pyside_dir)
     except:
         raise Exception("Failed to generate UI resources using pyside2 rcc!"
                         " Reinstalling pyside2 may fix the problem. If you "

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -38,7 +38,8 @@ class StringSignaler(QtCore.QObject):
 def make_resources(qrc_path=None, result_path=None):
     import PySide2
     pyside_dir = os.path.dirname(PySide2.__file__)
-    full_rcc_path = os.path.join(pyside_dir, 'pyside2-rcc')
+    full_pyside2rcc_path = os.path.join(pyside_dir, 'pyside2-rcc')
+    full_rcc_path = os.path.join(pyside_dir, 'rcc')
     this_dir = os.path.dirname(os.path.realpath(__file__))
     if not qrc_path:
         qrc_path = os.path.join(this_dir, 'resources/resources.qrc')
@@ -59,12 +60,18 @@ def make_resources(qrc_path=None, result_path=None):
         return
 
     try:
-        subprocess.check_call([full_rcc_path] + args)
+        subprocess.check_call([full_pyside2rcc_path] + args)
     except:
         pass
     else:
         return
-
+    try:
+        subprocess.check_call([full_rcc_path, '-g', 'python', qrc_path,
+                               '-o', result_path], cwd=pyside_dir)
+    except:
+        pass
+    else:
+        return
     try:
         subprocess.check_call(['rcc', '-g', 'python', qrc_path,
                                '-o', result_path], cwd=pyside_dir)

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -82,11 +82,16 @@ except ImportError:
 
 
 def _new_qapp():
-    app = QtWidgets.QApplication
+    app = QtWidgets.QApplication.instance()
+    create_new = False
+    if not app:
+        app = QtWidgets.QApplication
+        app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+        create_new = True
     os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
-    app.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
     app.setEffectEnabled(QtCore.Qt.UI_AnimateCombo, False)
-    app = app(sys.argv)
+    if create_new:
+        app = app(sys.argv)
     style_file = QtCore.QFile(':styles/styles/dark/dark.qss')
     style_file.open(QtCore.QFile.ReadOnly | QtCore.QFile.Text)
     stream = QtCore.QTextStream(style_file)

--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -160,7 +160,26 @@ class NxtActionContainer(QtWidgets.QWidget):
 
 
 class BoolUserPrefAction(NxtAction):
+    """NxtAction that saves state between sessions via preference key."""
     def __init__(self, text, pref_key, default=False, parent=None):
+        """NxtAction that saves state between sessions via preference key
+
+        Note that default checked state is set during initialization, before
+        signals have been hooked up. Meaning any later-connected function is not
+        automatically called to "kick start" the application state. Either
+        build that into the start of the UI, or call your action once manually
+        to kick start.
+
+        :param text: Action description.
+        :type text: str
+        :param pref_key: Preference key to save at
+        :type pref_key: str
+        :param default: Deafult value, loads default state from user pref, only
+        falling back to this default when no save exists, defaults to False
+        :type default: bool, optional
+        :param parent: Action parent, defaults to None
+        :type parent: QObject, optional
+        """
         super(BoolUserPrefAction, self).__init__(text, parent)
         self.setCheckable(True)
         self.pref_key = pref_key
@@ -1167,13 +1186,13 @@ class StageViewActions(NxtActionContainer):
             state = self.grid_action.isChecked()
             self.main_window.view.toggle_grid(state)
 
-        self.grid_action = NxtAction(text='Toggle Grid',
-                                     parent=self)
+        self.grid_action = BoolUserPrefAction('Toggle Grid',
+                                              user_dir.USER_PREF.SHOW_GRID,
+                                              default=True,
+                                              parent=self)
         self.grid_action.setShortcut('Ctrl+;')
         self.grid_action.setToolTip('Show / Hide the Grid')
         self.grid_action.setWhatsThis('Shows or hides the grid for all tabs.')
-        self.grid_action.setCheckable(True)
-        self.grid_action.setChecked(True)
         self.grid_action.triggered.connect(toggle_grid)
         grid_icon = QtGui.QIcon()
         grid_icn_on = QtGui.QPixmap(':icons/icons/grid_pressed.png')

--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -1585,6 +1585,14 @@ class ExecuteActions(NxtActionContainer):
         self.run_build_action.setWhatsThis('Runs build specified by the '
                                            'current value of build view.')
 
+        self.toggle_skip_action = NxtAction(text='Toggle Skippoint',
+                                            parent=self)
+        self.toggle_skip_action.setWhatsThis('Toggle skippoint on the selected'
+                                             'node(s)')
+        self.toggle_skip_action.setAutoRepeat(False)
+        self.toggle_skip_action.setShortcut('X')
+        self.toggle_skip_action.triggered.connect(lambda: self.main_window.model.toggle_skippoints())
+
         def stop():
             self.main_window.model.stop_build()
         self.stop_exec_action = NxtAction(text='Stop Execution', parent=self)

--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -1610,7 +1610,49 @@ class ExecuteActions(NxtActionContainer):
                                              'node(s)')
         self.toggle_skip_action.setAutoRepeat(False)
         self.toggle_skip_action.setShortcut('X')
-        self.toggle_skip_action.triggered.connect(lambda: self.main_window.model.toggle_skippoints())
+
+        def toggle_skip():
+            node_paths = self.toggle_skip_action.data()
+            self.toggle_skip_action.setData(None)
+            if not node_paths:
+                node_paths = self.main_window.model.get_selected_nodes()
+            if not node_paths:
+                logger.info("No nodes to toggle skip on.")
+                return
+            layer = self.main_window.model.top_layer.real_path
+            self.main_window.model.toggle_skippoints(node_paths, layer)
+        self.toggle_skip_action.triggered.connect(toggle_skip)
+
+        self.set_descendent_skips = NxtAction('Toggle Skip with Descendants',
+                                              parent=self)
+        self.set_descendent_skips.setWhatsThis('Toggles skip of the selected '
+                                               'node(s), applying the '
+                                               'skip state to all descendents')
+        self.set_descendent_skips.setAutoRepeat(False)
+        self.set_descendent_skips.setShortcut('Shift+X')
+
+        def toggle_descendant_skips():
+            node_paths = self.set_descendent_skips.data()
+            self.set_descendent_skips.setData(None)
+            if not node_paths:
+                node_paths = self.main_window.model.get_selected_nodes()
+            if not node_paths:
+                logger.info("No nodes to toggle skip on.")
+                return
+            node_count = len(node_paths)
+            if node_count > 1:
+                msg = ('Set skippoint for {} and '
+                       '{} other(s)'.format(node_paths[0], node_count - 1))
+            else:
+                msg = 'Set skippoint for {}'.format(node_paths[0])
+            model = self.main_window.model
+            model.undo_stack.beginMacro(msg)
+            for node_path in node_paths:
+                to_skip = not model.is_node_skippoint(node_path)
+                descendants = model.get_descendants(node_path)
+                model.set_skippoints(descendants + [node_path], to_skip)
+            model.undo_stack.endMacro()
+        self.set_descendent_skips.triggered.connect(toggle_descendant_skips)
 
         def stop():
             self.main_window.model.stop_build()

--- a/nxt_editor/actions.py
+++ b/nxt_editor/actions.py
@@ -1639,19 +1639,7 @@ class ExecuteActions(NxtActionContainer):
             if not node_paths:
                 logger.info("No nodes to toggle skip on.")
                 return
-            node_count = len(node_paths)
-            if node_count > 1:
-                msg = ('Set skippoint for {} and '
-                       '{} other(s)'.format(node_paths[0], node_count - 1))
-            else:
-                msg = 'Set skippoint for {}'.format(node_paths[0])
-            model = self.main_window.model
-            model.undo_stack.beginMacro(msg)
-            for node_path in node_paths:
-                to_skip = not model.is_node_skippoint(node_path)
-                descendants = model.get_descendants(node_path)
-                model.set_skippoints(descendants + [node_path], to_skip)
-            model.undo_stack.endMacro()
+            self.main_window.model.toggle_descendant_skips(node_paths)
         self.set_descendent_skips.triggered.connect(toggle_descendant_skips)
 
         def stop():

--- a/nxt_editor/colors.py
+++ b/nxt_editor/colors.py
@@ -17,6 +17,10 @@ ATTR_COLORS = {
     'dict': QColor('#984dab'),
 }
 
+GRAPH_BG_COLOR = QColor(35, 35, 35)
+START_COLOR = QColor("#1bd40b")
+SKIP_COLOR = QColor("#f0880a")
+
 LAYER_COLORS = [
     QColor('#991C24'),  # dark red
     QColor('#C91781'),  # fuschia

--- a/nxt_editor/colors.py
+++ b/nxt_editor/colors.py
@@ -20,6 +20,7 @@ ATTR_COLORS = {
 GRAPH_BG_COLOR = QColor(35, 35, 35)
 START_COLOR = QColor("#1bd40b")
 SKIP_COLOR = QColor("#f0880a")
+BREAK_COLOR = QColor(255, 0, 0)
 
 LAYER_COLORS = [
     QColor('#991C24'),  # dark red

--- a/nxt_editor/commands.py
+++ b/nxt_editor/commands.py
@@ -1308,7 +1308,7 @@ class SetNodesAreSkipPoints(QUndoCommand):
         if len(self.node_paths) == 1:
             path_str = self.node_paths[0]
         else:
-            "Multiple nodes"
+            path_str = "Multiple nodes"
         if self.to_skip:
             self.setText("Add skippoint to {}".format(path_str))
         else:

--- a/nxt_editor/commands.py
+++ b/nxt_editor/commands.py
@@ -1285,6 +1285,45 @@ class SetNodeExecuteSources(SetNodeAttributeValue):
         self.setText("Set {} exec input to {}".format(self.node_path, val))
 
 
+class SetNodesAreSkipPoints(QUndoCommand):
+
+    """Set nodes as skip points"""
+
+    def __init__(self, node_paths, to_skip, layer_path, model):
+        super(SetNodesAreSkipPoints, self).__init__()
+        self.node_paths = node_paths
+        self.to_skip = to_skip
+        self.model = model
+        self.layer_path = layer_path
+
+    @processing
+    def redo(self):
+        if self.to_skip:
+            func = self.model._add_skippoint
+        else:
+            func = self.model._remove_skippoint
+        for node_path in self.node_paths:
+            func(node_path, self.layer_path)
+        self.model.nodes_changed.emit(tuple(self.node_paths))
+        if len(self.node_paths) == 1:
+            path_str = self.node_paths[0]
+        else:
+            "Multiple nodes"
+        if self.to_skip:
+            self.setText("Add skippoint to {}".format(path_str))
+        else:
+            self.setText("Remove skippoint from {}".format(path_str))
+
+    @processing
+    def undo(self):
+        if not self.to_skip:
+            func = self.model._add_skippoint
+        else:
+            func = self.model._remove_skippoint
+        for node_path in self.node_paths:
+            func(node_path, self.layer_path)
+
+
 class SetNodeBreakPoint(QUndoCommand):
 
     """Set node as a break point"""

--- a/nxt_editor/dockwidgets/build_view.py
+++ b/nxt_editor/dockwidgets/build_view.py
@@ -10,6 +10,7 @@ from nxt_editor.dockwidgets.dock_widget_base import DockWidgetBase
 from nxt import nxt_path
 from nxt_editor.dockwidgets.layer_manager import LetterCheckboxDelegeate
 import nxt_editor
+from nxt_editor import colors
 
 logger = logging.getLogger(nxt_editor.LOGGER_NAME)
 
@@ -453,9 +454,9 @@ class BuildModel(QtCore.QAbstractTableModel):
             if column == self.BREAK_COLUMN and is_break:
                 return QtGui.QBrush(QtCore.Qt.red)
             if column == self.SKIP_COLUMN and is_skip:
-                return QtGui.QBrush(QtCore.Qt.blue)
+                return colors.SKIP_COLOR
             if column == self.START_COLUMN and is_start:
-                return QtGui.QBrush(QtCore.Qt.green)
+                return colors.START_COLOR
             if column == self.PATH_COLUMN and next_run:
                 return QtGui.QBrush(QtCore.Qt.red)
         if role == QtCore.Qt.ForegroundRole:

--- a/nxt_editor/dockwidgets/build_view.py
+++ b/nxt_editor/dockwidgets/build_view.py
@@ -349,7 +349,7 @@ class BuildTable(QtWidgets.QTableView):
 
     def on_build_idx_changed(self, build_idx):
         if self.model().stage_model.can_build_run():
-            model_index = self.model().index(build_idx + 1, 0)
+            model_index = self.model().index(build_idx, 0)
         else:
             model_index = self.model().index(0, 0)
         self.scrollTo(model_index, self.ScrollHint.PositionAtCenter)
@@ -423,7 +423,7 @@ class BuildModel(QtCore.QAbstractTableModel):
                 return idx_path
         next_run = False
         if self.stage_model.is_build_setup():
-            next_run = row == self.stage_model.last_built_idx + 1
+            next_run = row == self.stage_model.last_built_idx
         elif row == 0:
             next_run = True
         is_start = self.stage_model.get_is_node_start(idx_path)

--- a/nxt_editor/dockwidgets/build_view.py
+++ b/nxt_editor/dockwidgets/build_view.py
@@ -1,6 +1,7 @@
 # Builtin
 import logging
 import time
+from turtle import color
 
 # External
 from Qt import QtWidgets, QtGui, QtCore
@@ -452,7 +453,7 @@ class BuildModel(QtCore.QAbstractTableModel):
                 return QtCore.Qt.Checked if next_run else QtCore.Qt.Unchecked
         if role == QtCore.Qt.BackgroundRole:
             if column == self.BREAK_COLUMN and is_break:
-                return QtGui.QBrush(QtCore.Qt.red)
+                return colors.BREAK_COLOR
             if column == self.SKIP_COLUMN and is_skip:
                 return colors.SKIP_COLOR
             if column == self.START_COLUMN and is_start:

--- a/nxt_editor/dockwidgets/build_view.py
+++ b/nxt_editor/dockwidgets/build_view.py
@@ -473,7 +473,10 @@ class BuildModel(QtCore.QAbstractTableModel):
             self.stage_model.set_breakpoints([path], not current_break)
             return True
         if column == self.SKIP_COLUMN:
-            current_skip = self.stage_model.is_node_skippoint(path)
-            self.stage_model.set_skippoints([path], not current_skip)
+            modifiers = QtWidgets.QApplication.keyboardModifiers()
+            if modifiers == QtCore.Qt.ShiftModifier:
+                self.stage_model.toggle_descendant_skips([path])
+            else:
+                self.stage_model.toggle_skippoints([path])
             return True
         return False

--- a/nxt_editor/dockwidgets/output_log.py
+++ b/nxt_editor/dockwidgets/output_log.py
@@ -334,7 +334,9 @@ class OutputLog(DockWidgetBase):
                 curr_rt_layer.cache_layer.was_during_node_exec(msg_time)):
             return
         if self.log_filter_button.is_level_enabled(nxt_log.NODEOUT):
-            self.write_rich_output(val.replace('<', '&lt;'), raw=True)
+            # Intentionally breaking html syntax here. Printing type(object)
+            # was being interpreted as html. <class 'type'>
+            self.write_rich_output(val.replace('<', '&lt;'))
 
     def _write_raw_output(self, val):
         """Write text to the raw output textedit. Dose NOT write to the rich
@@ -353,7 +355,7 @@ class OutputLog(DockWidgetBase):
         else:
             self.raw_output_textedit.verticalScrollBar().setValue(cur)
 
-    def write_rich_output(self, val, level=None, raw=False):
+    def write_rich_output(self, val, level=None):
         """Neighbor to write_raw_output. Use of write as naming is specific,
         no newlines created from thin air, must come form input.
 

--- a/nxt_editor/dockwidgets/output_log.py
+++ b/nxt_editor/dockwidgets/output_log.py
@@ -334,7 +334,7 @@ class OutputLog(DockWidgetBase):
                 curr_rt_layer.cache_layer.was_during_node_exec(msg_time)):
             return
         if self.log_filter_button.is_level_enabled(nxt_log.NODEOUT):
-            self.write_rich_output(val)
+            self.write_rich_output(val.replace('<', '&lt;'), raw=True)
 
     def _write_raw_output(self, val):
         """Write text to the raw output textedit. Dose NOT write to the rich
@@ -353,7 +353,7 @@ class OutputLog(DockWidgetBase):
         else:
             self.raw_output_textedit.verticalScrollBar().setValue(cur)
 
-    def write_rich_output(self, val, level=None):
+    def write_rich_output(self, val, level=None, raw=False):
         """Neighbor to write_raw_output. Use of write as naming is specific,
         no newlines created from thin air, must come form input.
 

--- a/nxt_editor/integration/__init__.py
+++ b/nxt_editor/integration/__init__.py
@@ -3,23 +3,11 @@ import sys
 import subprocess
 import importlib
 
-import bpy
-
-b_major, b_minor, b_patch = bpy.app.version
-
 
 class NxtIntegration(object):
 
     def __init__(self, name):
         self.name = name
-
-    @staticmethod
-    def show_message(message, title, icon='INFO'):
-
-        def draw(self, *args):
-            self.layout.label(text=message)
-
-        bpy.context.window_manager.popup_menu(draw, title=title, icon=icon)
 
     @classmethod
     def setup(cls):
@@ -61,18 +49,11 @@ class NxtIntegration(object):
             global_name = module_name
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
-        pkg = 'nxt-editor'
-        if b_major == 2:
-            exe = bpy.app.binary_path_python
-        else:
-            exe = sys.executable
-        subprocess.run([exe, "-m", "pip", "install", pkg],
-                       check=True, env=environ_copy)
+        subprocess.run([sys.executable, "-m", "pip", "install",
+                        package_name], check=True, env=environ_copy)
+
         success = self._safe_import_package(package_name=package_name,
                                             global_name=global_name)
-        NxtIntegration.show_message('NXT package Installed! '
-                                    'You may need to restart Blender.',
-                                    'Success!')
         return success
 
     @staticmethod
@@ -85,14 +66,9 @@ class NxtIntegration(object):
         """
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
-        if b_major == 2:
-            exe = bpy.app.binary_path_python
-        else:
-            exe = sys.executable
-        subprocess.run([exe, "-m", "pip", "install", "-U",
+        subprocess.run([sys.executable, "-m", "pip", "install", "-U",
                         package_name], check=True, env=environ_copy)
-        NxtIntegration.show_message('NXT package updated! '
-                                    'Please restart Blender.', 'Success!')
+        print('Please restart your DCC or Python interpreter')
 
     def check_for_nxt_core(self, install=False):
         has_core = self._safe_import_package('nxt')
@@ -103,8 +79,7 @@ class NxtIntegration(object):
         success = self._install_and_import_package('nxt',
                                                    package_name='nxt-core')
         if not success:
-            NxtIntegration.show_message('Failed to import and/or install '
-                                        'nxt-editor.', 'Failed!')
+            print('Failed to import and/or install nxt-core')
         return success
 
     def check_for_nxt_editor(self, install=False):
@@ -116,8 +91,7 @@ class NxtIntegration(object):
         success = self._install_and_import_package('nxt_editor',
                                                    package_name='nxt-editor')
         if not success:
-            NxtIntegration.show_message('Failed to import and/or install '
-                                        'nxt-editor.', 'Failed!')
+            print('Failed to import and/or install nxt-editor')
         return success
 
     def update(self):
@@ -137,11 +111,7 @@ class NxtIntegration(object):
         """
         environ_copy = dict(os.environ)
         environ_copy["PYTHONNOUSERSITE"] = "1"
-        if b_major == 2:
-            exe = bpy.app.binary_path_python
-        else:
-            exe = sys.executable
-        subprocess.run([exe, "-m", "pip", "uninstall",
+        subprocess.run([sys.executable, "-m", "pip", "uninstall",
                         package_name, '-y'], check=True, env=environ_copy)
 
     def uninstall(self):
@@ -149,9 +119,7 @@ class NxtIntegration(object):
             self._uninstall_package('nxt-core')
         if self.check_for_nxt_editor():
             self._uninstall_package('nxt-editor')
-        NxtIntegration.show_message('NXT was uninstalled, sorry '
-                                    'to see you go.', 'Uninstalled!')
-        # print('Please restart your DCC or Python interpreter')
+        print('Please restart your DCC or Python interpreter')
 
     def launch_nxt(self):
         raise NotImplementedError('Your DCC needs it own nxt launch method.')

--- a/nxt_editor/integration/blender/README.md
+++ b/nxt_editor/integration/blender/README.md
@@ -1,6 +1,8 @@
 # Installation
-**This is an experimental version of nxt_blender. Save early, save often.**  
+**This is an experimental version of nxt_blender. Save early, save often.**   
 This is a Blender addon for nxt. Note that it will access the internet to install.  
+Please read all the steps below before starting.
+
 _In some of our testing we found that we needed to install Python on 
 the system inorder for Blender to be able to open the NXT editor. If you 
 get strange import errors when you try to import `nxt_editor`, try 
@@ -9,7 +11,7 @@ installing Python (same version as Blender's) on your machine._
 ### By hand (if you're familiar with pip)
 1. Locate the path to blenders Python interpreter
     - In Blender, you can run `sys.exec_prefix` to find the folder containing the Python executable
-2. Open Terminal or CMD (If you're using Windows)
+2. Open Terminal, CMD, ect. - Must have elevated permissions
 3. Run: `/path/to/blender/python.exe -m pip install nxt-editor`
 4. Start Blender
 5. Open the addon manager (Edit > Preferences > Add-ons)
@@ -18,19 +20,21 @@ installing Python (same version as Blender's) on your machine._
 
 
 ### Automated
-1. Open the addon manager (Edit > Preferences > Add-ons)
-2. Click "Install" and select the `nxt_blender.py` file provided with this addon zip
-3. Enable the `NXT Blender` and twirl down the addon preferences
-3. Click `Install NXT dependencies`
-   - The installation may take a minute or two, during this time Blender will be unresponsive
-   - Optionally open the console window before running the script, so you can see what's happening
-4. Restart Blender
+1. Launch Blender with elevated permissions
+2. Open the addon manager (Edit > Preferences > Add-ons)
+3. Click "Install" and select the `nxt_blender.py` file provided with this addon zip
+4. Enable the `NXT Blender` and twirl down the addon preferences
+5. Click `Install NXT dependencies`
+   - It is recommended to open the console window before running the script, so you can see what's happening. Window > Toggle System Console.
+   - The installation may take a minute or two, during this time Blender will be unresponsive.
+6. Restart Blender
  
 # Usage
 - Ensure the `NXT Blender` addon is enabled
 - To launch NXT navigate the newly created `NXT` menu and select `Open Editor`
 
 # Updating
+_These steps also require elevated permissions for Blender or the terminal._
 ### By hand (if you're familiar with pip)
 1. In terminal or cmd run: `/path/to/blender/python.exe -m pip install -U nxt-editor nxt`
 2. Restart Blender
@@ -48,6 +52,7 @@ _or_
 3. Restart Blender
 
 # Uninstall
+_These steps also require elevated permissions for Blender or the terminal._
 ### By hand (if you're familiar with pip)
 1. Open the addon manager (Edit > Preferences > Add-ons)
 2. Locate the `NXT Blender` and twirl down the addon preferences

--- a/nxt_editor/integration/blender/README.md
+++ b/nxt_editor/integration/blender/README.md
@@ -1,6 +1,10 @@
 # Installation
 **This is an experimental version of nxt_blender. Save early, save often.**  
 This is a Blender addon for nxt. Note that it will access the internet to install.  
+_In some of our testing we found that we needed to install Python on 
+the system inorder for Blender to be able to open the NXT editor. If you 
+get strange import errors when you try to import `nxt_editor`, try 
+installing Python (same version as Blender's) on your machine._
 
 ### By hand (if you're familiar with pip)
 1. Locate the path to blenders Python interpreter

--- a/nxt_editor/integration/blender/__init__.py
+++ b/nxt_editor/integration/blender/__init__.py
@@ -20,10 +20,13 @@ class Blender(NxtIntegration):
     def __init__(self):
         super(Blender, self).__init__(name='blender')
         b_major, b_minor, b_patch = bpy.app.version
-        if b_major != 2 or b_minor < 80:
+        if b_major == 2 and b_minor < 80:
             raise RuntimeError('Blender version is not compatible with this '
                                'version of nxt.')
-        addons_dir = bpy.utils.user_resource('SCRIPTS', 'addons')
+        if b_major == 2:
+            addons_dir = bpy.utils.user_resource('SCRIPTS', 'addons')
+        else:
+            addons_dir = os.path.join(bpy.utils.user_resource('SCRIPTS'), '/addons')
         self.addons_dir = addons_dir.replace(os.sep, '/')
         self.instance = None
         self.nxt_qapp = QtWidgets.QApplication.instance()

--- a/nxt_editor/integration/blender/__init__.py
+++ b/nxt_editor/integration/blender/__init__.py
@@ -1,8 +1,9 @@
 # Builtin
+import atexit
 import os
 import shutil
+import subprocess
 import sys
-import atexit
 
 # External
 import bpy
@@ -14,6 +15,7 @@ from nxt_editor.integration import NxtIntegration
 import nxt_editor
 
 __NXT_INTEGRATION__ = None
+b_major, b_minor, b_patch = bpy.app.version
 
 
 class Blender(NxtIntegration):
@@ -26,10 +28,19 @@ class Blender(NxtIntegration):
         if b_major == 2:
             addons_dir = bpy.utils.user_resource('SCRIPTS', 'addons')
         else:
-            addons_dir = os.path.join(bpy.utils.user_resource('SCRIPTS'), '/addons')
+            addons_dir = os.path.join(bpy.utils.user_resource('SCRIPTS'),
+                                      '/addons')
         self.addons_dir = addons_dir.replace(os.sep, '/')
         self.instance = None
         self.nxt_qapp = QtWidgets.QApplication.instance()
+
+    @staticmethod
+    def show_message(message, title, icon='INFO'):
+
+        def draw(self, *args):
+            self.layout.label(text=message)
+
+        bpy.context.window_manager.popup_menu(draw, title=title, icon=icon)
 
     @classmethod
     def setup(cls):
@@ -38,6 +49,58 @@ class Blender(NxtIntegration):
         integration_filepath = self.get_integration_filepath()
         shutil.copy(integration_filepath, self.addons_dir)
         bpy.ops.preferences.addon_enable(module='nxt_' + self.name)
+
+    def _install_and_import_package(self, module_name, package_name=None,
+                                    global_name=None):
+        """Calls a subprocess to pip install the given package name and then
+        attempts to import the new package.
+
+        :param module_name: Desired module to import after install
+        :param package_name: pip package name
+        :param global_name: Global name to access the module if different
+        than the module name.
+        :raises: subprocess.CalledProcessError
+        :return: bool
+        """
+        if package_name is None:
+            package_name = module_name
+        if global_name is None:
+            global_name = module_name
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        pkg = 'nxt-editor'
+        if b_major == 2:
+            exe = bpy.app.binary_path_python
+        else:
+            exe = sys.executable
+        print('INSTLALING: ' + pkg)
+        subprocess.run([exe, "-m", "pip", "install", pkg],
+                       check=True, env=environ_copy)
+        success = self._safe_import_package(package_name=package_name,
+                                            global_name=global_name)
+        Blender.show_message('NXT package Installed! '
+                             'You may need to restart Blender.',
+                             'Success!')
+        return success
+
+    @staticmethod
+    def _update_package(package_name):
+        """Calls a subprocess to pip update the given package name.
+
+        :param package_name: pip package name
+        :raises: subprocess.CalledProcessError
+        :return: None
+        """
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        if b_major == 2:
+            exe = bpy.app.binary_path_python
+        else:
+            exe = sys.executable
+        subprocess.run([exe, "-m", "pip", "install", "-U",
+                        package_name], check=True, env=environ_copy)
+        Blender.show_message('NXT package updated! '
+                             'Please restart Blender.', 'Success!')
 
     @classmethod
     def update(cls):
@@ -50,13 +113,13 @@ class Blender(NxtIntegration):
 
     @classmethod
     def launch_nxt(cls):
-        self = cls()
-        os.environ[NXT_DCC_ENV_VAR] = 'blender'
         global __NXT_INTEGRATION__
-        if not __NXT_INTEGRATION__:
-            __NXT_INTEGRATION__ = self
-        else:
+        if __NXT_INTEGRATION__:
             self = __NXT_INTEGRATION__
+        else:
+            self = cls()
+            __NXT_INTEGRATION__ = self
+        os.environ[NXT_DCC_ENV_VAR] = 'blender'
         if self.instance:
             self.instance.show()
             return
@@ -71,20 +134,19 @@ class Blender(NxtIntegration):
 
         def unregister_nxt():
             self.instance = None
-            if self.nxt_qapp:
-                self.nxt_qapp.quit()
-                self.nxt_qapp = None
 
         nxt_win.close_signal.connect(unregister_nxt)
         nxt_win.show()
+        # Forces keyboard focus
+        nxt_win.activateWindow()
         atexit.register(nxt_win.close)
         self.instance = nxt_win
         return self
 
     def quit_nxt(self):
         if self.instance:
-            self.instance.close()
             atexit.unregister(self.instance.close)
+            self.instance.close()
         if self.nxt_qapp:
             self.nxt_qapp.quit()
         global __NXT_INTEGRATION__
@@ -97,3 +159,32 @@ class Blender(NxtIntegration):
                                             interpreter_exe=bpy.app.binary_path,
                                             exe_script_args=args)
 
+    def check_for_nxt_core(self, install=False):
+        success = super(Blender, self).check_for_nxt_core(install=install)
+        if not success:
+            Blender.show_message('Failed to import and/or install '
+                                 'nxt-editor.', 'Failed!')
+        return success
+
+    @staticmethod
+    def _uninstall_package(package_name):
+        """Calls a subprocess to pip uninstall the given package name. Will
+        NOT prompt the user to confrim uninstall.
+
+        :param package_name: pip package name
+        :raises: subprocess.CalledProcessError
+        :return: None
+        """
+        environ_copy = dict(os.environ)
+        environ_copy["PYTHONNOUSERSITE"] = "1"
+        if b_major == 2:
+            exe = bpy.app.binary_path_python
+        else:
+            exe = sys.executable
+        subprocess.run([exe, "-m", "pip", "uninstall",
+                        package_name, '-y'], check=True, env=environ_copy)
+
+    def uninstall(self):
+        super(Blender, self).uninstall()
+        Blender.show_message('NXT was uninstalled, sorry '
+                             'to see you go.', 'Uninstalled!')

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -702,7 +702,9 @@ class MainWindow(QtWidgets.QMainWindow):
             logger.debug("Successfully set up new tab.")
             self.last_focused_tab = tab_index
             self.update_implicit_action()
-            view.toggle_grid(user_dir.user_prefs[user_dir.USER_PREF.SHOW_GRID])
+            view.toggle_grid(
+                user_dir.user_prefs.get(user_dir.USER_PREF.SHOW_GRID, True)
+            )
             model.destroy_cmd_port.connect(self.update_cmd_port_action)
         else:
             logger.critical("Failed to set up new tab.")

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -1227,7 +1227,7 @@ class MenuBar(QtWidgets.QMenuBar):
             return
         widget = action.data()
         tab_index = self.main_window.open_files_tab_widget.indexOf(widget)
-        if tab_index is not -1:
+        if tab_index != -1:
             self.main_window.open_files_tab_widget.setCurrentIndex(tab_index)
             return
         if action.isChecked():

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -476,7 +476,6 @@ class MainWindow(QtWidgets.QMainWindow):
             model.target_layer_changed.connect(self.update_target_color)
             model.comp_layer_changed.connect(self.update_target_color)
             self.update_target_color()
-            self.update_grid_action()
             self.update()  # TODO: Make this better
         self.set_waiting_cursor(False)
 
@@ -708,7 +707,7 @@ class MainWindow(QtWidgets.QMainWindow):
             logger.debug("Successfully set up new tab.")
             self.last_focused_tab = tab_index
             self.update_implicit_action()
-            self.update_grid_action()
+            view.toggle_grid(user_dir.user_prefs[user_dir.USER_PREF.SHOW_GRID])
             model.destroy_cmd_port.connect(self.update_cmd_port_action)
         else:
             logger.critical("Failed to set up new tab.")
@@ -746,11 +745,6 @@ class MainWindow(QtWidgets.QMainWindow):
             state = False
         self.execute_actions.enable_cmd_port_action.setChecked(state)
         self.execute_actions.enable_cmd_port_action.blockSignals(False)
-
-    def update_grid_action(self):
-        self.view_actions.grid_action.blockSignals(True)
-        self.view_actions.grid_action.setChecked(self.model.show_grid)
-        self.view_actions.grid_action.blockSignals(False)
 
     def update_implicit_action(self):
         self.view_actions.implicit_action.blockSignals(True)

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -559,7 +559,16 @@ class MainWindow(QtWidgets.QMainWindow):
         self.set_waiting_cursor(False)
 
     def save_layer_as(self, layer=None, open_in_new_tab=True):
-        """Returns True if save was successful.
+        """Prompt the user to select a save location for a layer.
+
+        If no layer is specified the target layer is used.
+
+        :param layer: path to prompt for, defaults to target layer.
+        :type layer: nxt_layer.SpecLayer, optional
+        :param open_in_new_tab: If True, open the layer in a new tab after save
+        :type start: str, optional
+        :return: True if save was successful, false otherwise.
+        :rtype: bool
         """
         if not layer:
             layer = self.model.target_layer

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -1054,6 +1054,7 @@ class NodeExecutionPlug(NodeGraphicsPlug):
         # If an output, or an non-special input.
         if (not self.is_input) or (not special_input):
             if self.is_root:
+                self.radius = NodeGraphicsItem.EXEC_PLUG_RADIUS
                 super(NodeExecutionPlug, self).paint(painter, option, widget)
             # For non-root non-specials, no drawing.
             return

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -597,10 +597,10 @@ class NodeGraphicsItem(graphic_type):
         # Internal Attrs
         # Exec
         draw_details = {}
-        in_pos = QtCore.QPointF(0, self.title_bounding_rect.height()/2)
+        in_pos = QtCore.QPointF(0, self.title_bounding_rect.height()*0.5)
         draw_details['in_pos'] = in_pos
         out_pos = QtCore.QPointF(self.max_width,
-                                 self.title_bounding_rect.height()/2)
+                                 self.title_bounding_rect.height()*0.5)
         draw_details['out_pos'] = out_pos
         draw_details['plug_color'] = QtGui.QColor(QtCore.Qt.white)
         exec_attr = nxt_node.INTERNAL_ATTRS.EXECUTE_IN
@@ -1075,7 +1075,7 @@ class NodeExecutionPlug(NodeGraphicsPlug):
             painter.drawRoundedRect(skip_rect, 4, 4)
         elif self.is_break:  # A red square
             self.radius = 8
-            painter.setBrush(QtCore.Qt.red)
+            painter.setBrush(colors.BREAK_COLOR)
             painter.setPen(shape_border_pen)
             painter.drawRect(self.radius * -1, self.radius * -1, self.radius * 2, self.radius * 2)
 

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -98,6 +98,9 @@ class NodeGraphicsItem(graphic_type):
         self.collapse_arrows = []
         self.node_enabled = None
         self.node_instance = None
+
+        self.model.build_idx_changed.connect(self.update_build_focus)
+        self.model.executing_changed.connect(self.update_build_focus)
         # draw node
         self.update_from_model()
 
@@ -700,13 +703,11 @@ class NodeGraphicsItem(graphic_type):
         super(NodeGraphicsItem, self).hoverLeaveEvent(event)
 
     def update_build_focus(self):
-        if not self.model.can_build_run():
+        if not self.model.executing:
             self.is_build_focus = False
             self.update()
             return
-        idx = self.model.last_built_idx + 1
-        build_focus = self.model.current_build_order[idx]
-        self.is_build_focus = build_focus == self.node_path
+        self.is_build_focus = self.node_path == self.model.current_build_order[self.model.last_built_idx]
         self.update()
 
     def update_from_model(self):

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -1002,6 +1002,10 @@ class NodeGraphicsPlug(QtWidgets.QGraphicsItem):
 
 
 class NodeExecutionPlug(NodeGraphicsPlug):
+    """Node Graphics Plug for the plugs in the execution position.
+
+    Handles drawing of exec plugs, as well as start, break, and skip points.
+    """
     def __init__(self, model, node_path, is_input, parent=None):
         super(NodeExecutionPlug, self).__init__(
             radius=NodeGraphicsItem.EXEC_PLUG_RADIUS,

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -597,10 +597,10 @@ class NodeGraphicsItem(graphic_type):
         # Internal Attrs
         # Exec
         draw_details = {}
-        in_pos = QtCore.QPointF(0, self.title_bounding_rect.height()/3)
+        in_pos = QtCore.QPointF(0, self.title_bounding_rect.height()/2)
         draw_details['in_pos'] = in_pos
         out_pos = QtCore.QPointF(self.max_width,
-                                 self.title_bounding_rect.height()/3)
+                                 self.title_bounding_rect.height()/2)
         draw_details['out_pos'] = out_pos
         draw_details['plug_color'] = QtGui.QColor(QtCore.Qt.white)
         exec_attr = nxt_node.INTERNAL_ATTRS.EXECUTE_IN
@@ -1054,28 +1054,28 @@ class NodeExecutionPlug(NodeGraphicsPlug):
             # For non-root non-specials, no drawing.
             return
         self._apply_lod_to_painter(painter)
-        if self.is_start:
-            self.radius = 18
-            # draw
-            pen = QtGui.QPen(QtGui.QColor(self.start_color), self.hover_width * 8)
-            painter.setPen(pen)
-            painter.setBrush(QtCore.Qt.green)
-            self._drawTriangle(painter, QtCore.QPointF(self.radius * -0.6, 0), self.radius)
-        elif self.is_skip:
-            painter.setBrush(QtCore.Qt.blue)
+        shape_border_pen = QtGui.QPen(colors.GRAPH_BG_COLOR, self.hover_width * 2)
+        if self.is_start:  # A green triangle, with a border of layer color
+            self.radius = 13
+            painter.setBrush(QtGui.QColor(self.start_color))
+            painter.setPen(shape_border_pen)
+            painter.drawPolygon(self._buildTriangle(QtCore.QPointF(self.radius * -0.6, 0), self.radius))
+            painter.setBrush(colors.START_COLOR)
             painter.setPen(QtCore.Qt.NoPen)
+            painter.drawPolygon(self._buildTriangle(QtCore.QPointF(self.radius * -0.6, 0), self.radius * .7))
+        elif self.is_skip:  # A short wide rect, a minus
             self.radius = 9
-            first_x = -10
-            self._drawTriangle(painter, QtCore.QPointF(first_x, 0), self.radius)
-            second_x = 2
-            self._drawTriangle(painter, QtCore.QPointF(second_x, 0), self.radius)
-        elif self.is_break:
+            painter.setBrush(colors.SKIP_COLOR)
+            painter.setPen(shape_border_pen)
+            skip_rect = QtCore.QRect(self.radius * -1, self.radius * -.6, self.radius * 2, self.radius)
+            painter.drawRoundedRect(skip_rect, 4, 4)
+        elif self.is_break:  # A red square
+            self.radius = 8
             painter.setBrush(QtCore.Qt.red)
-            painter.setPen(QtCore.Qt.NoPen)
+            painter.setPen(shape_border_pen)
             painter.drawRect(self.radius * -1, self.radius * -1, self.radius * 2, self.radius * 2)
 
-    def _drawTriangle(self, painter, offset, side_length):
-        # create triangle
+    def _buildTriangle(self, offset, side_length):
         polygon = QtGui.QPolygonF()
         step_angle = 120
         for i in [0, 1, 2, 3]:
@@ -1084,7 +1084,7 @@ class NodeExecutionPlug(NodeGraphicsPlug):
             y = side_length * 1.2 * math.sin(math.radians(step))
             polygon.append(QtCore.QPointF(x, y))
         polygon.translate(offset)
-        painter.drawPolygon(polygon)
+        return polygon
 
 
 class CollapseArrow(QtWidgets.QGraphicsItem):

--- a/nxt_editor/node_graphics_item.py
+++ b/nxt_editor/node_graphics_item.py
@@ -707,7 +707,7 @@ class NodeGraphicsItem(graphic_type):
             self.is_build_focus = False
             self.update()
             return
-        self.is_build_focus = self.node_path == self.model.current_build_order[self.model.last_built_idx]
+        self.is_build_focus = self.node_path == self.model.get_build_focus()
         self.update()
 
     def update_from_model(self):

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2297,6 +2297,8 @@ class StageModel(QtCore.QObject):
         except ValueError:
             # Can return without the below save in this case. If the node
             # path is not present, it's already "removed"
+            if layer_path == self.top_layer.real_path:
+                self.skips_changed.emit([])
             return
         user_dir.skippoints[layer_path] = layer_skips
         if layer_path == self.top_layer.real_path:

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2195,6 +2195,20 @@ class StageModel(QtCore.QObject):
             self.set_skippoints(off, False, layer_path)
         self.undo_stack.endMacro()
 
+    def toggle_descendant_skips(self, node_paths, layer_path=None):
+        node_count = len(node_paths)
+        if node_count > 1:
+            msg = ('Set skippoint for {} and '
+                   '{} other(s)'.format(node_paths[0], node_count - 1))
+        else:
+            msg = 'Set skippoint for {}'.format(node_paths[0])
+        self.undo_stack.beginMacro(msg)
+        for node_path in node_paths:
+            to_skip = not self.is_node_skippoint(node_path)
+            descendants = self.get_descendants(node_path)
+            self.set_skippoints(descendants + [node_path], to_skip, layer_path)
+        self.undo_stack.endMacro()
+
     def set_skippoints(self, node_paths, to_skip, layer_path=None):
         if not layer_path:
             layer_path = self.top_layer.real_path

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2093,7 +2093,12 @@ class StageModel(QtCore.QObject):
             node_paths = self.selection
         if not node_paths:
             return
-        layer_path = self.get_layer_path(layer, fallback=LAYERS.TOP)
+        layer_path = self.get_layer_path(layer,
+                                         fallback=self.top_layer.real_path)
+        if not layer_path:
+            logger.warning('Please save your graph to use breaks.')
+            self.request_ding.emit()
+            return
         on = []
         off = []
         for node_path in node_paths:
@@ -2180,6 +2185,10 @@ class StageModel(QtCore.QObject):
         """
         if not layer_path:
             layer_path = self.top_layer.real_path
+        if not layer_path:
+            logger.warning('Please save your graph to use skips.')
+            self.request_ding.emit()
+            return
         on = []
         off = []
         for node_path in node_paths:
@@ -2211,6 +2220,12 @@ class StageModel(QtCore.QObject):
         :param layer_path: Layer to set skips on, defaults to top layer.
         :type layer_path: str, optional
         """
+        if not layer_path:
+            layer_path = self.top_layer.real_path
+        if not layer_path:
+            logger.warning('Please save your graph to use skips.')
+            self.request_ding.emit()
+            return
         node_count = len(node_paths)
         if node_count > 1:
             msg = ('Set skippoint for {} and '
@@ -2236,6 +2251,10 @@ class StageModel(QtCore.QObject):
         """
         if not layer_path:
             layer_path = self.top_layer.real_path
+        if not layer_path:
+            logger.warning('Please save your graph to use skips.')
+            self.request_ding.emit()
+            return
         cmd = SetNodesAreSkipPoints(node_paths, to_skip, layer_path, self)
         self.undo_stack.push(cmd)
 

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2170,11 +2170,7 @@ class StageModel(QtCore.QObject):
         user_dir.breakpoints[layer_path] = layer_breaks
         self.breaks_changed.emit(layer_breaks)
 
-    def toggle_skippoints(self, node_paths=None, layer_path=None):
-        if not node_paths:
-            node_paths = self.selection
-        if not node_paths:
-            return
+    def toggle_skippoints(self, node_paths, layer_path=None):
         if not layer_path:
             layer_path = self.top_layer.real_path
         on = []

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2103,7 +2103,7 @@ class StageModel(QtCore.QObject):
             node_paths = self.selection
         if not node_paths:
             return
-        layer_path = self.get_layer_path(layer, fallback=LAYERS.TARGET)
+        layer_path = self.get_layer_path(layer, fallback=LAYERS.TOP)
         on = []
         off = []
         for node_path in node_paths:

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2171,6 +2171,13 @@ class StageModel(QtCore.QObject):
         self.breaks_changed.emit(layer_breaks)
 
     def toggle_skippoints(self, node_paths, layer_path=None):
+        """Reverse the skip status of all given node paths.
+
+        :param node_paths: Node paths to toggle.
+        :type node_paths: iterable
+        :param layer_path: Layer to set skips on, defaults to top layer.
+        :type layer_path: str, optional
+        """
         if not layer_path:
             layer_path = self.top_layer.real_path
         on = []
@@ -2196,6 +2203,14 @@ class StageModel(QtCore.QObject):
         self.undo_stack.endMacro()
 
     def toggle_descendant_skips(self, node_paths, layer_path=None):
+        """Reverse the skip point status of each node given, applying the same
+        status to all descendant nodes.
+
+        :param node_paths: Root node(s) to change skip status of.
+        :type node_paths: iterable
+        :param layer_path: Layer to set skips on, defaults to top layer.
+        :type layer_path: str, optional
+        """
         node_count = len(node_paths)
         if node_count > 1:
             msg = ('Set skippoint for {} and '
@@ -2210,18 +2225,44 @@ class StageModel(QtCore.QObject):
         self.undo_stack.endMacro()
 
     def set_skippoints(self, node_paths, to_skip, layer_path=None):
+        """Set the skip status of given nodes.
+
+        :param node_paths: Nodes to set skip status of.
+        :type node_paths: iterable
+        :param to_skip: Whether to set nodes to skip or not.
+        :type to_skip: bool
+        :param layer_path: Layer to set skips on, defaults to top layer.
+        :type layer_path: str, optional
+        """
         if not layer_path:
             layer_path = self.top_layer.real_path
         cmd = SetNodesAreSkipPoints(node_paths, to_skip, layer_path, self)
         self.undo_stack.push(cmd)
 
     def is_node_skippoint(self, node_path, layer_path=None):
+        """Returns True/False based on whether a node is currently a skippoint.
+
+        :param node_path: Node to check.
+        :type node_path: str
+        :param layer_path: Layer path to check within, defaults to top layer.
+        :type layer_path: str, optional
+        :return: Whether given node is a skip.
+        :rtype: bool
+        """
         if not layer_path:
             layer_path = self.top_layer.real_path
         layer_skips = user_dir.skippoints.get(layer_path, tuple())
         return node_path in layer_skips
 
     def _add_skippoint(self, node_path, layer_path):
+        """Internal(not undo-able) method to make a node a skip point.
+
+        :param node_path: Node to make a skip point.
+        :type node_path: str
+        :param layer_path: Layer to set skip for.
+        :type layer_path: str
+        :raises ValueError: If inputs are not complete.
+        """
         if not (node_path and layer_path):
             raise ValueError("Must provide node and layer path.")
         node_path = str(node_path)
@@ -2236,6 +2277,14 @@ class StageModel(QtCore.QObject):
             self.skips_changed.emit([])
 
     def _remove_skippoint(self, node_path, layer_path):
+        """Internal(not undo-able) method to make a node not a skip point.
+
+        :param node_path: Node to remove as a skip point.
+        :type node_path: str
+        :param layer_path: Layer to set skip for.
+        :type layer_path: str
+        :raises ValueError: If inputs are not complete.
+        """
         if not (node_path and layer_path):
             raise ValueError("Must provide node and layer path.")
         node_path = str(node_path)
@@ -2250,11 +2299,6 @@ class StageModel(QtCore.QObject):
             # path is not present, it's already "removed"
             return
         user_dir.skippoints[layer_path] = layer_skips
-        if layer_path == self.top_layer.real_path:
-            self.skips_changed.emit([])
-
-    def _clear_skippoints(self, layer_path):
-        user_dir.skippoints.pop(layer_path)
         if layer_path == self.top_layer.real_path:
             self.skips_changed.emit([])
 

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2251,7 +2251,7 @@ class StageModel(QtCore.QObject):
         """
         if not layer_path:
             layer_path = self.top_layer.real_path
-        layer_skips = user_dir.skippoints.get(layer_path, tuple())
+        layer_skips = user_dir.skippoints.get(layer_path, [])
         return node_path in layer_skips
 
     def _add_skippoint(self, node_path, layer_path):

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2951,14 +2951,14 @@ class StageModel(QtCore.QObject):
         self._set_build_paused(True, focus=False)
 
     def get_build_focus(self):
-        """Build "focus" is the next-up node that will run when stepped.
+        """Build "focus" is the currently running node.
 
-        :return: next node path that will run when stepped/resumed.
+        :return: node path currently running, if running.
         :rtype: str
         """
         if not self.can_build_run():
             return ''
-        return self.current_build_order[self.last_built_idx + 1]
+        return self.current_build_order[self.last_built_idx]
 
     @property
     def last_built_idx(self):

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -50,7 +50,6 @@ class StageModel(QtCore.QObject):
     build_paused_changed = QtCore.Signal(bool)
     processing = QtCore.Signal(bool)
     data_state_changed = QtCore.Signal(bool)
-    show_grid_changed = QtCore.Signal(bool)
     implicit_connections_changed = QtCore.Signal(bool)
     layer_color_changed = QtCore.Signal(object)
     comp_layer_changed = QtCore.Signal(object)
@@ -103,7 +102,6 @@ class StageModel(QtCore.QObject):
         self.refresh_exec_framing_from_pref()
         # model states
         self._data_state = DATA_STATE.RESOLVED
-        self._show_grid = True
         self._implicit_connections = True
         # graph layers
         self._comp_layer = stage.build_stage()
@@ -442,15 +440,6 @@ class StageModel(QtCore.QObject):
     def data_state(self, value):
         self._data_state = value
         self.data_state_changed.emit(value)
-
-    @property
-    def show_grid(self):
-        return self._show_grid
-
-    @show_grid.setter
-    def show_grid(self, value):
-        self._show_grid = value
-        self.show_grid_changed.emit(value)
 
     @property
     def implicit_connections(self):

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -2295,6 +2295,9 @@ class StageModel(QtCore.QObject):
             layer = self.comp_layer
         if self.node_exists(node_path, layer=layer):
             return False
+        if node_path == nxt_path.WORLD:
+            # If we're in a graph, the world node is always at least implied.
+            return True
         parent_path = nxt_path.get_parent_path(node_path)
         children = self.get_children(parent_path, layer=layer,
                                      include_implied=True)

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -121,7 +121,7 @@ class StageView(QtWidgets.QGraphicsView):
         self.prev_build_focus_path = None
 
         # local attributes
-        self.show_grid = True
+        self.show_grid = user_prefs[USER_PREF.SHOW_GRID]
         # connection attribute used when drawing connections
         self.potential_connection = None
 
@@ -297,7 +297,6 @@ class StageView(QtWidgets.QGraphicsView):
             self.show_grid = not self.show_grid
         else:
             self.show_grid = state
-        self.model.show_grid = self.show_grid
         self.update()
 
     def frame_all(self):

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -17,6 +17,7 @@ from nxt_editor.node_graphics_item import (NodeGraphicsItem, NodeGraphicsPlug,
 from nxt_editor.connection_graphics_item import AttrConnectionGraphic
 from nxt_editor.dialogs import NxtWarningDialog
 from nxt_editor.commands import *
+from nxt_editor import colors
 from .user_dir import USER_PREF, user_prefs
 
 logger = logging.getLogger(nxt_editor.LOGGER_NAME)
@@ -594,8 +595,7 @@ class StageView(QtWidgets.QGraphicsView):
         super(StageView, self).drawBackground(painter, rect)
 
         rect = self.sceneRect()
-        color = QtGui.QColor(35, 35, 35)
-        painter.fillRect(rect, QtGui.QBrush(color))
+        painter.fillRect(rect, QtGui.QBrush(colors.GRAPH_BG_COLOR))
 
         left = int(rect.left()) - (int(rect.left()) % self.draw_grid_size)
         top = int(rect.top()) - (int(rect.top()) % self.draw_grid_size)

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -121,7 +121,7 @@ class StageView(QtWidgets.QGraphicsView):
         self.prev_build_focus_path = None
 
         # local attributes
-        self.show_grid = user_prefs[USER_PREF.SHOW_GRID]
+        self.show_grid = user_prefs.get(USER_PREF.SHOW_GRID, True)
         # connection attribute used when drawing connections
         self.potential_connection = None
 

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -914,7 +914,7 @@ class StageView(QtWidgets.QGraphicsView):
             items_released_on = self.items(event.pos())
             # using the 1 index item here because the 0 index thing will always be the connection
             if len(items_released_on) > 1:
-                if type(items_released_on[1]) is NodeGraphicsPlug:
+                if isinstance(items_released_on[1], NodeGraphicsPlug):
                     dropped_plug = items_released_on[1]
                     dropped_node_path = dropped_plug.parentItem().node_path
                     locked = self.model.get_node_locked(dropped_node_path)

--- a/nxt_editor/stage_view.py
+++ b/nxt_editor/stage_view.py
@@ -137,7 +137,6 @@ class StageView(QtWidgets.QGraphicsView):
         self.model.node_moved.connect(self.handle_node_move)
         self.model.selection_changed.connect(self.on_model_selection_changed)
         self.model.frame_items.connect(self.frame_nodes)
-        self.model.build_idx_changed.connect(self.on_build_idx_changed)
         self.model.collapse_changed.connect(self.handle_collapse_changed)
 
         # initialize the view
@@ -1126,21 +1125,6 @@ class StageView(QtWidgets.QGraphicsView):
         # if isinstance(graphic, AttrConnectionGraphic):
         #     return graphic.tgt_path
         return None
-
-    def on_build_idx_changed(self, build_idx):
-        prev_graphic = self.get_node_graphic(self.prev_build_focus_path)
-        if prev_graphic is not None:
-            prev_graphic.update_build_focus()
-        focus_path = self.model.get_build_focus()
-        if not focus_path:
-            self.prev_build_focus_path = None
-            return
-        graphic = self.get_node_graphic(focus_path)
-        if not graphic:
-            self.prev_build_focus_path = None
-            return
-        self.prev_build_focus_path = focus_path
-        graphic.update_build_focus()
 
     def on_model_selection_changed(self, new_selection):
         if not new_selection:

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(nxt_editor.LOGGER_NAME)
 USER_PREFS_PATH = os.path.join(PREF_DIR, 'prefs.json')
 EDITOR_CACHE_PATH = os.path.join(PREF_DIR, 'editor_cache')
 BREAKPOINT_FILE = os.path.join(PREF_DIR, 'breakpoints')
+SKIPPOINT_FILE = os.path.join(PREF_DIR, 'skippoints')
 HOTKEYS_PREF = os.path.join(PREF_DIR, 'hotkeys.json')
 MAX_RECENT_FILES = 10
 
@@ -319,6 +320,7 @@ class MultiFilePref(object):
 user_prefs = JsonPref(USER_PREFS_PATH)
 hotkeys = JsonPref(HOTKEYS_PREF)
 breakpoints = JsonPref(BREAKPOINT_FILE)
+skippoints = JsonPref(SKIPPOINT_FILE)
 editor_cache = PicklePref(EDITOR_CACHE_PATH)
 editor_cache.set_handler(USER_PREF.LAST_OPEN, LastOpenedHandler)
 # TODO as a session starts(or ends?), let's create a symlink to

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -74,6 +74,7 @@ class USER_PREF():
     SHOW_DBL_CLICK_MSG = 'show_double_click_message'
     SHOW_CE_DATA_STATE = 'show_code_editor_data_state'
     DING = 'ding'
+    SHOW_GRID = 'show_grid'
 
 
 class EDITOR_CACHE():

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -1,7 +1,7 @@
 {
   "EDITOR": {
     "MAJOR": 3,
-    "MINOR": 11,
-    "PATCH": 1
+    "MINOR": 12,
+    "PATCH": 0
   }
 }

--- a/nxt_env.yml
+++ b/nxt_env.yml
@@ -2,8 +2,8 @@ name: nxt_editor
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.9
   - qt.py=1.1
-  - pyside2=5.11.1
+  - pyside2=5.13.2
   - twine
   - requests

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nxt-dev/nxt_editor",
     packages=setuptools.find_packages(),
-    python_requires='>=2.7, <3.8',
+    python_requires='>=2.7, <3.10',
     install_requires=['nxt-core<1.0,>=0.13',
                       'qt.py==1.1',
                       'pyside2==5.11.1'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     url="https://github.com/nxt-dev/nxt_editor",
     packages=setuptools.find_packages(),
     python_requires='>=2.7, <3.10',
-    install_requires=['nxt-core<1.0,>=0.13',
+    install_requires=['nxt-core<1.0,>=0.14',
                       'qt.py==1.1',
                       'pyside2>=5.11,<=5.16'
                       ],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     python_requires='>=2.7, <3.10',
     install_requires=['nxt-core<1.0,>=0.13',
                       'qt.py==1.1',
-                      'pyside2==5.11.1'
+                      'pyside2>=5.11,<=5.16'
                       ],
     package_data={
         # covers text nxt files


### PR DESCRIPTION
## Additions:
`+` Added support for Blender 3.0
`+` Skip Points
`+` Skip points
## Changes:
`*` Updated setup.py to allow Python 3.9.
`*` Updated Python and PySide2 versions in conda env yml.
`*` Bug fix: It was not possible to close and reopen NXT in Blender because we did not take proper care of the fact that a `qapp` had already been started in the current interpreter session.
`*` Node output is more reliably rendered in the rich output log.
`*` Fix build view and in-graph drawing of current node being off by one
`*` Show grid now saves as a preference
`*` Removing Travis testing on this repo.
## Notes:
`...` Fixed syntax warnings in Python 3.9
`...` Updated PySide2 ceiling to `5.15.x`.
`...` Raised `nxt-core` floor version.
`...` fixes #148
`...` fixes #113
`...` fix to auto resources generation code
`...` Better error message when resource generation fails
