### PR TITLE
Attr display bug

### DIFF
--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -207,8 +207,7 @@ class StageModel(QtCore.QObject):
         if node_paths in (None, [], ()):
             node_paths = self.get_selected_nodes()
         self._set_attr_display_state(node_paths, state)
-        # Fixme: Should only redraw the nodes in the selection list
-        self.comp_layer_changed.emit(self.comp_layer)
+        self.nodes_changed.emit(node_paths)
 
     def get_attr_display_state(self, node_path):
         """Gets the attribute display state for a given node path if there is


### PR DESCRIPTION
`*` Bug fix: when updating node attr display, child nodes would slightly overlap their parent node.

Took way to long to find the cause of this, still not totally sure but it has something to do with the animation logic being triggered out of order when we blindly redraw everything. It's fixed now and it's more efficient.

Old:
![image](https://user-images.githubusercontent.com/54835354/196314543-fdb2eddf-5ac7-485d-9bb2-8b2fe6c15a19.png)


New: 
![image](https://user-images.githubusercontent.com/54835354/196314425-b66bfc0e-74cd-4336-a999-ef786531289a.png)
