### PR TITLE
Release editor-v3.13.0

### DIFF
--- a/nxt_editor/integration/blender/nxt_blender.py
+++ b/nxt_editor/integration/blender/nxt_blender.py
@@ -25,7 +25,7 @@ nxt_package_name = 'nxt-editor'
 
 bl_info = {
     "name": "NXT Blender",
-    "blender": (3, 0, 0),
+    "blender": (3, 4, 0),
     "version": (0, 3, 0),
     "location": "NXT > Open Editor",
     "wiki_url": "https://nxt-dev.github.io/",

--- a/nxt_editor/stage_model.py
+++ b/nxt_editor/stage_model.py
@@ -207,8 +207,7 @@ class StageModel(QtCore.QObject):
         if node_paths in (None, [], ()):
             node_paths = self.get_selected_nodes()
         self._set_attr_display_state(node_paths, state)
-        # Fixme: Should only redraw the nodes in the selection list
-        self.comp_layer_changed.emit(self.comp_layer)
+        self.nodes_changed.emit(node_paths)
 
     def get_attr_display_state(self, node_path):
         """Gets the attribute display state for a given node path if there is

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -1,7 +1,7 @@
 {
   "EDITOR": {
     "MAJOR": 3,
-    "MINOR": 12,
-    "PATCH": 1
+    "MINOR": 13,
+    "PATCH": 0
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/nxt-dev/nxt_editor",
     packages=setuptools.find_packages(),
-    python_requires='>=2.7, <3.10',
+    python_requires='>=2.7, <3.11',
     install_requires=['nxt-core<1.0,>=0.14',
                       'qt.py==1.1',
                       'pyside2>=5.11,<=5.16'


### PR DESCRIPTION
## Additions:
`+` Support for Python 3.11
`+` Support for Blender 3.4
## Changes:
`*` Bug fix: when updating node attr display, child nodes would slightly overlap their parent node.
