### PR TITLE
fix (PySide6): Bugfix following PySide6 update

### DIFF
--- a/nxt_editor/dockwidgets/code_editor.py
+++ b/nxt_editor/dockwidgets/code_editor.py
@@ -778,7 +778,7 @@ class NxtCodeEditor(QtWidgets.QPlainTextEdit):
         return QtWidgets.QPlainTextEdit.focusOutEvent(self, event)
 
     def wheelEvent(self, event):
-        delta = event.delta()
+        delta = event.angleDelta().y() / 8
         if event.modifiers() == QtCore.Qt.ControlModifier:
             if delta > 0:
                 self.set_font_size(delta=0.5)

--- a/nxt_editor/dockwidgets/syntax.py
+++ b/nxt_editor/dockwidgets/syntax.py
@@ -161,7 +161,7 @@ class PythonHighlighter(QSyntaxHighlighter):
         while start >= 0:
             match = delimiter.match(text)
             # Look for the ending delimiter
-            end = match.capturedStart() + (start + add)
+            end = match.capturedStart() - (start + add)
             # Ending delimiter on this line?
             if end >= add:
                 length = end - start + add + match.capturedLength()


### PR DESCRIPTION
Fix multiline styling, which was stopping before the end of the multiline.
Fix a wheel scroll bug on NxtCodeEditor.