### PR TITLE
Copy old prefs flow

### DIFF
--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -93,6 +93,8 @@ def launch_editor(paths=None, start_rpc=False):
         app = existing
     else:
         app = _new_qapp()
+    from nxt_editor.dialogs import CopyPrefsDialogue
+    CopyPrefsDialogue.show_message()  # Show message if upgrade possible
     instance = show_new_editor(paths, start_rpc)
     app.setActiveWindow(instance)
     if not existing:

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -93,8 +93,8 @@ def launch_editor(paths=None, start_rpc=False):
         app = existing
     else:
         app = _new_qapp()
-    from nxt_editor.dialogs import CopyPrefsDialogue
-    CopyPrefsDialogue.show_message()  # Show message if upgrade possible
+    from nxt_editor.dialogs import UpgradePrefsDialogue
+    UpgradePrefsDialogue.confirm_upgrade_if_possible()
     instance = show_new_editor(paths, start_rpc)
     app.setActiveWindow(instance)
     if not existing:

--- a/nxt_editor/__init__.py
+++ b/nxt_editor/__init__.py
@@ -84,7 +84,7 @@ def _new_qapp():
     return app
 
 
-def launch_editor(paths=None, start_rpc=True):
+def launch_editor(paths=None, start_rpc=False):
     """Launch an instance of the editor. Will attach to existing QApp if found,
     otherwise will create and open one.
     """
@@ -100,7 +100,7 @@ def launch_editor(paths=None, start_rpc=True):
     return instance
 
 
-def show_new_editor(paths=None, start_rpc=True):
+def show_new_editor(paths=None, start_rpc=False):
     path = None
     if paths and isinstance(paths, list):
         path = paths[0]

--- a/nxt_editor/constants.py
+++ b/nxt_editor/constants.py
@@ -26,7 +26,9 @@ class FONTS(object):
     DEFAULT_SIZE = 10
 
 
-_pref_dir_name = str(EDITOR_VERSION.MAJOR)
-PREF_DIR = os.path.join(USER_DIR, 'prefs', _pref_dir_name)
+PREF_DIR_INT = EDITOR_VERSION.MAJOR
+PREF_DIR_NAME = 'prefs'
+_pref_dir_num = str(PREF_DIR_INT)
+PREF_DIR = os.path.join(USER_DIR, PREF_DIR_NAME, _pref_dir_num)
 
 NXT_WEBSITE = 'https://nxt-dev.github.io/'

--- a/nxt_editor/dialogs.py
+++ b/nxt_editor/dialogs.py
@@ -411,30 +411,29 @@ class NxtConfirmDialog(QtWidgets.QMessageBox):
         return False
 
 
-class CopyPrefsDialogue(NxtConfirmDialog):
-    title_text = (f'Copy version {user_dir.UPGRADE_PREFS_FROM_VERSION} '
-                  f'Preferences?')
-    button_text = {
-        NxtConfirmDialog.Ok: f'Copy v'
-                             f'{user_dir.UPGRADE_PREFS_FROM_VERSION} prefs',
-        NxtConfirmDialog.Cancel: 'Use default preferences'
-    }
-    info = ('Would you like to copy preferences from an older version of '
-            'NXT?\nSome things like the window layout may not be preserved.')
-
-    def __int__(self):
-        super(CopyPrefsDialogue, self).__init__(text=self.title_text,
-                                                info=self.info,
-                                                button_text=self.button_text)
+class UpgradePrefsDialogue(NxtConfirmDialog):
+    def __int__(self, title_text, info, button_text):
+        super(UpgradePrefsDialogue, self).__init__(text=title_text,
+                                                   info=info,
+                                                   button_text=button_text)
 
     @classmethod
-    def show_message(cls):
+    def confirm_upgrade_if_possible(cls):
+
         if not user_dir.UPGRADABLE_PREFS:
             return
-        do_upgrade = super().show_message(text=cls.title_text, info=cls.info,
-                                          button_text=cls.button_text)
+        from_version = user_dir.UPGRADE_PREFS_FROM_VERSION
+        title_text = f'Copy version {from_version} Preferences?'
+        button_text = {
+            NxtConfirmDialog.Ok: f'Copy v{from_version} prefs',
+            NxtConfirmDialog.Cancel: 'Use default preferences'
+        }
+        i = ('Would you like to copy preferences from an older version of NXT?'
+             '\nSome things like the window layout may not be preserved.')
+        do_upgrade = super().show_message(text=title_text, info=i,
+                                          button_text=button_text)
         if do_upgrade:
-            user_dir.upgrade_prefs()
+            user_dir.upgrade_prefs(user_dir.UPGRADABLE_PREFS)
 
 
 class UnsavedLayersDialogue(QtWidgets.QDialog):

--- a/nxt_editor/dialogs.py
+++ b/nxt_editor/dialogs.py
@@ -391,6 +391,7 @@ class NxtConfirmDialog(QtWidgets.QMessageBox):
         self.setIcon(icon)
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
         self.setStandardButtons(self.Ok | self.Cancel)
+        self.setWindowTitle(text)
         if button_text:
             self.setButtonText(self.Ok, button_text.get(self.Ok, 'Ok'))
             self.setButtonText(self.Cancel, button_text.get(self.Cancel,

--- a/nxt_editor/dialogs.py
+++ b/nxt_editor/dialogs.py
@@ -410,6 +410,32 @@ class NxtConfirmDialog(QtWidgets.QMessageBox):
         return False
 
 
+class CopyPrefsDialogue(NxtConfirmDialog):
+    title_text = (f'Copy version {user_dir.UPGRADE_PREFS_FROM_VERSION} '
+                  f'Preferences?')
+    button_text = {
+        NxtConfirmDialog.Ok: f'Copy v'
+                             f'{user_dir.UPGRADE_PREFS_FROM_VERSION} prefs',
+        NxtConfirmDialog.Cancel: 'Use default preferences'
+    }
+    info = ('Would you like to copy preferences from an older version of '
+            'NXT?\nSome things like the window layout may not be preserved.')
+
+    def __int__(self):
+        super(CopyPrefsDialogue, self).__init__(text=self.title_text,
+                                                info=self.info,
+                                                button_text=self.button_text)
+
+    @classmethod
+    def show_message(cls):
+        if not user_dir.UPGRADABLE_PREFS:
+            return
+        do_upgrade = super().show_message(text=cls.title_text, info=cls.info,
+                                          button_text=cls.button_text)
+        if do_upgrade:
+            user_dir.upgrade_prefs()
+
+
 class UnsavedLayersDialogue(QtWidgets.QDialog):
     @classmethod
     def save_before_exit(cls, stage_models, main_window):

--- a/nxt_editor/integration/maya/plug-ins/nxt_maya.py
+++ b/nxt_editor/integration/maya/plug-ins/nxt_maya.py
@@ -107,7 +107,7 @@ class NxtUiCmd(om.MPxCommand):
                 if __NXT_INSTANCE__:
                     __NXT_INSTANCE__.close()
                 return
-        nxt_win = nxt_editor.main_window.MainWindow()
+        nxt_win = nxt_editor.show_new_editor()
         if 'win32' in sys.platform:
             # gives nxt it's own entry on taskbar
             nxt_win.setWindowFlags(QtCore.Qt.Window)

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -52,7 +52,7 @@ class MainWindow(QtWidgets.QMainWindow):
     new_log_signal = QtCore.Signal(logging.LogRecord)
     font_size_changed = QtCore.Signal(int)
 
-    def __init__(self, filepath=None, parent=None, start_rpc=True):
+    def __init__(self, filepath=None, parent=None, start_rpc=False):
         """Create NXT window.
 
         :param parent: parent to attach this UI to.

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -20,7 +20,7 @@ else:
 
 # Internal
 from nxt.constants import USER_DIR
-from nxt_editor.constants import PREF_DIR
+from nxt_editor.constants import PREF_DIR, PREF_DIR_INT, PREF_DIR_NAME
 import nxt_editor
 
 logger = logging.getLogger(nxt_editor.LOGGER_NAME)
@@ -32,7 +32,9 @@ BREAKPOINT_FILE = os.path.join(PREF_DIR, 'breakpoints')
 SKIPPOINT_FILE = os.path.join(PREF_DIR, 'skippoints')
 HOTKEYS_PREF = os.path.join(PREF_DIR, 'hotkeys.json')
 MAX_RECENT_FILES = 10
-
+JSON_PREFS = [USER_PREFS_PATH, BREAKPOINT_FILE, SKIPPOINT_FILE, HOTKEYS_PREF]
+UPGRADABLE_PREFS = []
+UPGRADE_PREFS_FROM_VERSION = -1
 broken_files = {}
 
 
@@ -48,7 +50,51 @@ def ensure_pref_dir_exists():
         raise Exception('Failed to generate user dir {}' + USER_DIR)
 
 
+def check_for_upgradable_prefs():
+    """
+    Identify preference files that can be safely upgraded
+    between major editor versions. Only existing preference files
+    from the nearest older version are copied; missing files are skipped
+    without warnings.
+    """
+    global UPGRADABLE_PREFS
+    global UPGRADE_PREFS_FROM_VERSION
+    for pref_file in JSON_PREFS:
+        if os.path.isfile(pref_file):
+            break
+    else:  # Didn't find any json prefs in current version prefs
+        dir_num = PREF_DIR_INT - 1
+        while dir_num > -1:
+            old_pref_dir = os.path.join(USER_DIR, PREF_DIR_NAME, str(dir_num))
+            for pref_file in JSON_PREFS:
+                file_name = os.path.basename(pref_file)
+                old_pref_file = os.path.join(old_pref_dir, file_name)
+                if os.path.isfile(old_pref_file):
+                    # In the future if we change the structure of the json
+                    # prefs we'll need a way to convert them or skip
+                    UPGRADABLE_PREFS.append(old_pref_file)
+            if UPGRADABLE_PREFS:
+                UPGRADE_PREFS_FROM_VERSION = dir_num
+                break
+            dir_num -= 1
+
+
+def upgrade_prefs():
+    """
+    Copies old 'upgradeable' prefs to current pref dir, will eat and
+    exception raised by shutil.copy. In the future this function may do more
+    than simply copy.
+    """
+    for pref_file in UPGRADABLE_PREFS:
+        try:
+            shutil.copy(pref_file, PREF_DIR)
+        except Exception as e:
+            logger.error(e)
+            logger.error(f'Failed to copy old pref file: {pref_file}')
+
+
 ensure_pref_dir_exists()
+check_for_upgradable_prefs()
 
 
 class USER_PREF():

--- a/nxt_editor/user_dir.py
+++ b/nxt_editor/user_dir.py
@@ -33,8 +33,6 @@ SKIPPOINT_FILE = os.path.join(PREF_DIR, 'skippoints')
 HOTKEYS_PREF = os.path.join(PREF_DIR, 'hotkeys.json')
 MAX_RECENT_FILES = 10
 JSON_PREFS = [USER_PREFS_PATH, BREAKPOINT_FILE, SKIPPOINT_FILE, HOTKEYS_PREF]
-UPGRADABLE_PREFS = []
-UPGRADE_PREFS_FROM_VERSION = -1
 broken_files = {}
 
 
@@ -50,15 +48,17 @@ def ensure_pref_dir_exists():
         raise Exception('Failed to generate user dir {}' + USER_DIR)
 
 
-def check_for_upgradable_prefs():
+def get_upgradable_prefs():
     """
     Identify preference files that can be safely upgraded
     between major editor versions. Only existing preference files
     from the nearest older version are copied; missing files are skipped
-    without warnings.
+    without warnings. Returns a list of prefs that can upgrade and the
+    versio number they're coming from.
+    :returns: (list, int)
     """
-    global UPGRADABLE_PREFS
-    global UPGRADE_PREFS_FROM_VERSION
+    upgradable_prefs = []
+    upgrade_prefs_from_version = -1
     for pref_file in JSON_PREFS:
         if os.path.isfile(pref_file):
             break
@@ -72,20 +72,22 @@ def check_for_upgradable_prefs():
                 if os.path.isfile(old_pref_file):
                     # In the future if we change the structure of the json
                     # prefs we'll need a way to convert them or skip
-                    UPGRADABLE_PREFS.append(old_pref_file)
-            if UPGRADABLE_PREFS:
-                UPGRADE_PREFS_FROM_VERSION = dir_num
+                    upgradable_prefs.append(old_pref_file)
+            if upgradable_prefs:
+                upgrade_prefs_from_version = dir_num
                 break
             dir_num -= 1
+    return upgradable_prefs, upgrade_prefs_from_version
 
 
-def upgrade_prefs():
+def upgrade_prefs(prefs_to_upgrade):
     """
     Copies old 'upgradeable' prefs to current pref dir, will eat and
     exception raised by shutil.copy. In the future this function may do more
     than simply copy.
+    :param prefs_to_upgrade: List of pref filepaths to upgrade
     """
-    for pref_file in UPGRADABLE_PREFS:
+    for pref_file in prefs_to_upgrade:
         try:
             shutil.copy(pref_file, PREF_DIR)
         except Exception as e:
@@ -94,7 +96,8 @@ def upgrade_prefs():
 
 
 ensure_pref_dir_exists()
-check_for_upgradable_prefs()
+# Must check these before we setup the defaults at the bottom of this file
+UPGRADABLE_PREFS, UPGRADE_PREFS_FROM_VERSION = get_upgradable_prefs()
 
 
 class USER_PREF():


### PR DESCRIPTION
`!` Changed defaults for RPC server so it's off, also committed to core (https://github.com/nxt-dev/nxt/commit/579e0c49137fda53d2c50e6002a68fb801fd832c).
`+` Added ability to copy preferences from an older version of NXT during UI launch.
`...` Fixed Maya plugin to use the correct launch method for the main window.

---

To test you must update your local `version.json` to have a major version higher than 3.
![image](https://github.com/user-attachments/assets/c1fa2322-5d9f-459c-9e0a-7f8acbbf3912)
