### PR TITLE
Release editor-v4.0.2

### DIFF
--- a/build/release_footer.md
+++ b/build/release_footer.md
@@ -22,6 +22,6 @@ See the [latest release of nxt-blender](https://github.com/nxt-dev/nxt-blender/r
 - By Hand: `/path/to/python.exe -m pip install -U nxt-editor`
 
 
-## Maya(2019-2025) Installation/Update
+## Maya(2025 or newer) Installation/Update
 1. Download Maya module(nxt_maya.zip)
 2. Extract and follow `README.md` inside  

--- a/nxt_editor/dockwidgets/dock_widget_base.py
+++ b/nxt_editor/dockwidgets/dock_widget_base.py
@@ -99,10 +99,14 @@ class DockWidgetBase(QDockWidget):
             (model.destroyed, self.on_stage_model_destroyed)
         ]
         for model_signal, my_func in self.model_signal_connections:
-            if connect:
-                model_signal.connect(my_func)
-            else:
-                model_signal.disconnect(my_func)
+            try:
+                if connect:
+                    model_signal.connect(my_func)
+                else:
+                    model_signal.disconnect(my_func)
+            except RuntimeError as e:
+                state = 'connect' if connect else 'disconnect'  # py 3.10 safe
+                logger.debug(f'Failed to {state} signal! {e}')
         self.model_signal_connections = []
 
     def on_stage_model_destroyed(self):

--- a/nxt_editor/dockwidgets/widget_builder.py
+++ b/nxt_editor/dockwidgets/widget_builder.py
@@ -1,6 +1,6 @@
 # Built-in
 import logging
-import ast
+from functools import partial
 try:
     from collections.abc import Iterable
 except ImportError:
@@ -814,12 +814,12 @@ class Button(QtWidgets.QPushButton):
                 action = QtWidgets.QAction(text, self)
                 if menu_data.get(self.SELECTOR_ITEM_ATTR) == 'True':
                     title = menu_data.get(self.SELECTOR_TITLE_ATTR)
-                    action.triggered.connect(lambda p=menu_item_path, t=title:
-                                             self.selection_widget(p, t))
+                    action.triggered.connect(partial(self.selection_widget,
+                                                     node_path, title))
                 else:
-                    action.triggered.connect(lambda p=menu_item_path,
-                                             a=self.ITEM_PATH_ATTR:
-                                             self.execute_node_path(p, a))
+                    action.triggered.connect(partial(self.execute_node_path,
+                                                     menu_item_path,
+                                                     self.ITEM_PATH_ATTR))
                 items.append(action)
 
         ContextMenu(stage_model=self.stage_model,
@@ -870,9 +870,9 @@ class Button(QtWidgets.QPushButton):
         else:
             items = []
         # selector dialog
-        screen = QtWidgets.QApplication.desktop().screenNumber(
-            QtWidgets.QApplication.desktop().cursor().pos())
-        center = QtWidgets.QApplication.desktop().screenGeometry(screen).center()
+        cursor_pos = QtGui.QCursor.pos()
+        screen = QtWidgets.QApplication.screenAt(cursor_pos)
+        center = screen.geometry().center() if screen else QtCore.QPoint(0, 0)
         dialog = SelectionDialog(title=title, items=items, pos=center, parent=self)
         dialog.exec_()
         if not dialog.result():

--- a/nxt_editor/file_search.py
+++ b/nxt_editor/file_search.py
@@ -15,7 +15,8 @@ class SearchLineEdit(QtWidgets.QLineEdit):
         model.setNameFilterDisables(False)
         completer.setModel(model)
         completer.setCaseSensitivity(QtCore.Qt.CaseInsensitive)
-        completer.setCompletionMode(completer.UnfilteredPopupCompletion)
+        mode = completer.CompletionMode.UnfilteredPopupCompletion
+        completer.setCompletionMode(mode)
         completer.popup().setStyleSheet(parent.parent().stylesheet)
         self.returnPressed.connect(self.file_chosen.emit)
         self.setCompleter(completer)

--- a/nxt_editor/main_window.py
+++ b/nxt_editor/main_window.py
@@ -1355,20 +1355,18 @@ class MenuBar(QtWidgets.QMenuBar):
         )
 
     def about_message(self):
-        text = ('nxt {} \n'
-                'graph v{}\n'
-                'api v{}\n'
-                'editor v{}\n'
-                'Copyright (c) 2015-2020 '
-                'The nxt Authors').format(self.main_window.host_app,
-                                          GRAPH_VERSION.VERSION_STR,
-                                          API_VERSION.VERSION_STR,
-                                          EDITOR_VERSION.VERSION_STR)
+        import datetime, Qt
+        text = (f'nxt {self.main_window.host_app} \n'
+                f'graph v{GRAPH_VERSION.VERSION_STR}\n'
+                f'api v{API_VERSION.VERSION_STR}\n'
+                f'editor v{EDITOR_VERSION.VERSION_STR}\n'
+                f'Qt: {Qt.__binding__} {Qt.__qt_version__}\n'
+                f'Copyright (c) 2015-{datetime.datetime.now().year} '
+                f'The nxt Authors')
         message_box = QtWidgets.QMessageBox()
-        message_box.setWindowTitle('About nxt '
-                                   '({})'.format(EDITOR_VERSION.VERSION_STR))
+        message_box.setWindowTitle(f'About nxt ({EDITOR_VERSION.VERSION_STR})')
         message_box.setText(text)
-        message_box.setStandardButtons(message_box.Close)
+        message_box.setStandardButtons(message_box.StandardButton.Close)
         message_box.setIcon(message_box.Icon.Information)
         message_box.exec_()
 

--- a/nxt_editor/version.json
+++ b/nxt_editor/version.json
@@ -2,6 +2,6 @@
   "EDITOR": {
     "MAJOR": 4,
     "MINOR": 0,
-    "PATCH": 1
+    "PATCH": 2
   }
 }


### PR DESCRIPTION
## Changes:
`*` Fixed bug with `Ctrl+P` file searcher crashing NXT
`*` Fixed bug with about window crashing
`*` Extended about window to display PySide version
`*` Fixed bugs related to workflow tool context menus
`*` Catching error thrown by host Qt app when objects are flushed without NXT hearing about it. Probably not a permanent fix.
## Notes:
`...` fixed release footer to reflect the correct version of Maya supported
