### PR TITLE
Syntax highlighter: format every match on a line

### DIFF
--- a/nxt_editor/dockwidgets/syntax.py
+++ b/nxt_editor/dockwidgets/syntax.py
@@ -110,27 +110,28 @@ class PythonHighlighter(QSyntaxHighlighter):
         for (pat, index, fmt) in special_rules:
             self.rules.append((QRegExp(pat), index, fmt))
             self.special_rules.append((QRegExp(pat), index, fmt))
+        # Pattern strings of the special (token) rules, for nested detection
+        self.special_patterns = set(pat for (pat, _, _) in special_rules)
 
     def highlightBlock(self, text):
         """Apply syntax highlighting to the given block of text.
         """
+        # Nested tokens (${...${...}}) need one extra char highlighted.
+        # This is here because you can't do nested logic in regex
+        nested = 1 if text.count(tokens.TOKEN_PREFIX) > 1 else 0
         # Do other syntax formatting
-        for rule in self.rules:
-            expression, nth, formatting = rule
-            match = expression.match(text)
-            index = match.capturedStart()
-            # This is here because you can't do nested logic in regex
-            nested = 0
-            if rule in self.special_rules:
-                if text.count(tokens.TOKEN_PREFIX) > 1:
-                    nested = 1
-
-            while index >= 0:
+        for expression, nth, formatting in self.rules:
+            extra = nested if expression.pattern() in self.special_patterns else 0
+            # Iterate every match on the line, not just the first one
+            iterator = expression.globalMatch(text)
+            while iterator.hasNext():
+                match = iterator.next()
                 # We actually want the index of the nth match
                 index = match.capturedStart(nth)
+                if index < 0:
+                    continue
                 length = len(match.captured(nth))
-                self.setFormat(index, length + nested, formatting)
-                index = match.capturedStart(text)
+                self.setFormat(index, length + extra, formatting)
 
         self.setCurrentBlockState(0)
 


### PR DESCRIPTION
The highlighter loop only formatted the first match of each rule per line (`capturedStart(text)` returned -1 after the first hit). This iterates matches with `globalMatch` so all keywords, operators, strings and ${} tokens on a line get highlighted. Nested-token handling is unchanged, just computed once per block.