### PR TITLE
Code editor: code completion (jedi optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Only clone this repo if you're [contributing](CONTRIBUTING.md) to the NXT codeba
 Our releases are hosted on [PyPi](https://pypi.org/project/nxt-editor/).
 - Install:
     - `pip install nxt-editor`
+    - `pip install nxt-editor[completion]` to also get rich code completion (jedi)
 - Launch:
     - `nxt ui`
 - Update:

--- a/nxt_editor/completion/__init__.py
+++ b/nxt_editor/completion/__init__.py
@@ -1,0 +1,15 @@
+"""Host-aware code completion for the nxt code editor.
+
+A small MVC stack, imported explicitly by consumers (this __init__ stays
+free of Qt so the model/host layers are headless-testable):
+    * Model      -- hosts.py (DCC namespace providers), sources.py, model.py
+    * View       -- popup.py (CompletionPopup)
+    * Controller -- controller.py (CompletionController)
+
+The code editor widget owns a CompletionController and delegates to it.
+"""
+import logging
+
+import nxt_editor
+
+logger = logging.getLogger(nxt_editor.LOGGER_NAME)

--- a/nxt_editor/completion/context.py
+++ b/nxt_editor/completion/context.py
@@ -1,0 +1,93 @@
+"""Completion context: what the editor is asking to complete at the cursor.
+
+The context is a plain value object produced by inspecting the text left of
+the cursor. It is the single input to the completion model, keeping the model
+free of any Qt/editor knowledge.
+"""
+import re
+from enum import Enum
+
+from nxt import tokens
+
+# Trailing identifier left of the cursor (the prefix being typed).
+_IDENT_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]*$')
+
+
+class ContextKind(Enum):
+    """The kind of completion the cursor position calls for."""
+    NONE = 'none'              # nothing to complete
+    CODE = 'code'              # Python code -> jedi / fallback name lists
+    TOKEN_NODE = 'token-node'  # inside ${...} before a '.' -> node paths
+    TOKEN_ATTR = 'token-attr'  # inside ${path. -> attribute names
+
+
+class CompletionContext(object):
+    """Description of a completion request.
+
+    :param kind: ContextKind for this request.
+    :param prefix: The already typed text the candidates must start with.
+    :param source: The full editor buffer (jedi needs the whole document).
+    :param line: 1-based line of the cursor (jedi convention).
+    :param column: 0-based column of the cursor (jedi convention).
+    :param token_body: For TOKEN_* kinds, the text inside ${...} up to the
+    cursor.
+    """
+
+    def __init__(self, kind, prefix='', source='', line=1, column=0,
+                 token_body=''):
+        self.kind = kind
+        self.prefix = prefix
+        self.source = source
+        self.line = line
+        self.column = column
+        self.token_body = token_body
+
+    @property
+    def is_token(self):
+        return self.kind in (ContextKind.TOKEN_NODE, ContextKind.TOKEN_ATTR)
+
+    def __repr__(self):
+        return ('CompletionContext(kind={!r}, prefix={!r}, line={}, column={})'
+                .format(self.kind.value, self.prefix, self.line, self.column))
+
+
+def detect(source, line, column, jedi_enabled=True):
+    """Build a CompletionContext from buffer text and a cursor position.
+
+    :param source: Full editor text.
+    :param line: 1-based cursor line.
+    :param column: 0-based cursor column.
+    :param jedi_enabled: When False an empty code prefix yields NONE (the
+    static fallback can't usefully complete a bare '.').
+    :return: CompletionContext
+    """
+    lines = source.split('\n')
+    current = lines[line - 1] if 0 <= line - 1 < len(lines) else ''
+    left = current[:column]
+
+    # ${...} token context wins over Python code.
+    token_start = left.rfind(tokens.TOKEN_PREFIX)
+    in_token = (token_start != -1 and
+                tokens.TOKEN_SUFFIX not in left[token_start:])
+    if in_token:
+        body = left[token_start + len(tokens.TOKEN_PREFIX):]
+        if '.' in body:
+            attr_prefix = body.rpartition('.')[2]
+            return CompletionContext(ContextKind.TOKEN_ATTR, prefix=attr_prefix,
+                                     source=source, line=line, column=column,
+                                     token_body=body)
+        return CompletionContext(ContextKind.TOKEN_NODE, prefix=body,
+                                 source=source, line=line, column=column,
+                                 token_body=body)
+
+    # Python code context.
+    match = _IDENT_RE.search(left)
+    prefix = match.group(0) if match else ''
+    if not prefix:
+        # Empty prefix only completes attribute access right after a '.'.
+        if jedi_enabled and left.endswith('.'):
+            return CompletionContext(ContextKind.CODE, prefix='', source=source,
+                                     line=line, column=column)
+        return CompletionContext(ContextKind.NONE)
+    return CompletionContext(ContextKind.CODE, prefix=prefix, source=source,
+                             line=line, column=column)

--- a/nxt_editor/completion/controller.py
+++ b/nxt_editor/completion/controller.py
@@ -1,0 +1,135 @@
+"""CompletionController: the Controller of the completion MVC.
+
+Glues the editor (a QPlainTextEdit) to the model and popup view. It builds a
+CompletionContext from the cursor, queries the model (debounced for the jedi
+code path so typing stays responsive), filters by prefix, and drives the
+popup. Key handling for accept/navigate/dismiss is exposed for the editor.
+
+The editor must provide:
+    * textCursor(), toPlainText(), cursorRect(), viewport()  (QPlainTextEdit)
+    * insert_completion(text, prefix)   -- replace the active prefix
+    * set_completion_active(active)     -- toggle Tab/Enter edit actions
+"""
+from Qt import QtCore
+
+from nxt_editor.completion.context import ContextKind, detect
+from nxt_editor.completion.popup import CompletionPopup
+
+_DEBOUNCE_MS = 120
+
+
+class CompletionController(QtCore.QObject):
+    """Orchestrates context detection, model queries and the popup view."""
+
+    def __init__(self, editor, model, parent=None):
+        super(CompletionController, self).__init__(parent or editor)
+        self.editor = editor
+        self.model = model
+        self.popup = CompletionPopup(editor.viewport())
+        self.popup.accepted.connect(self._on_popup_accepted)
+        self._active_prefix = ''
+        self._pending_prefix = ''
+        self._debounce = QtCore.QTimer(self)
+        self._debounce.setSingleShot(True)
+        self._debounce.setInterval(_DEBOUNCE_MS)
+        self._debounce.timeout.connect(self._on_debounce)
+
+    def popup_visible(self):
+        return self.popup.isVisible()
+
+    # -- request flow -------------------------------------------------- #
+    def request(self, force=False):
+        """Compute a context for the cursor and show completions for it.
+        :param force: True when explicitly requested (Ctrl+Space), the jedi
+        debounce is skipped.
+        """
+        context = self._build_context()
+        if context.kind is ContextKind.NONE:
+            self.dismiss()
+            return
+        self._pending_prefix = context.prefix
+        # Debounce the jedi code path; tokens/fallback are cheap -> immediate.
+        if (context.kind is ContextKind.CODE and self.model.jedi_enabled
+                and not force):
+            self._debounce.start()
+        else:
+            self._show_for(context)
+
+    def _on_debounce(self):
+        context = self._build_context()
+        # Drop stale requests if the cursor moved off the queued prefix.
+        if (context.kind is not ContextKind.CODE or
+                context.prefix != self._pending_prefix):
+            return
+        self._show_for(context)
+
+    def _show_for(self, context):
+        names = self._rank(self.model.candidates(context), context.prefix)
+        if not names or (len(names) == 1 and names[0] == context.prefix):
+            self.dismiss()
+            return
+        self._active_prefix = context.prefix
+        self.popup.show_items(names, self.editor.cursorRect(),
+                              self.editor.viewport().height())
+        self.editor.set_completion_active(True)
+
+    # -- key handling -------------------------------------------------- #
+    def handle_key_press(self, event):
+        """Consume nav/accept/dismiss keys while the popup is up.
+        :return: True if the event was handled.
+        """
+        if not self.popup.isVisible():
+            return False
+        key = event.key()
+        if key in (QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return,
+                   QtCore.Qt.Key_Tab):
+            self.accept()
+            return True
+        if key in (QtCore.Qt.Key_Escape, QtCore.Qt.Key_Backtab):
+            self.dismiss()
+            return True
+        if key in (QtCore.Qt.Key_Up, QtCore.Qt.Key_Down,
+                   QtCore.Qt.Key_PageUp, QtCore.Qt.Key_PageDown):
+            self.popup.move_selection(key)
+            return True
+        return False
+
+    def accept(self):
+        text = self.popup.current_text()
+        if text:
+            self.editor.insert_completion(text, self._active_prefix)
+        self.dismiss()
+
+    def dismiss(self):
+        self._debounce.stop()
+        self.popup.hide()
+        self.editor.set_completion_active(False)
+
+    # -- internals ----------------------------------------------------- #
+    def _on_popup_accepted(self, text):
+        if text:
+            self.editor.insert_completion(text, self._active_prefix)
+        self.dismiss()
+
+    def _build_context(self):
+        cursor = self.editor.textCursor()
+        line = cursor.blockNumber() + 1
+        column = cursor.positionInBlock()
+        source = self.editor.toPlainText()
+        return detect(source, line, column,
+                      jedi_enabled=self.model.jedi_enabled)
+
+    @staticmethod
+    def _rank(names, prefix):
+        """Filter by prefix and order by relevance (best match first)."""
+        if not prefix:
+            # No prefix: just keep underscores out of the way.
+            return sorted(names, key=lambda n: (n.startswith('_'), n.lower()))
+        low = prefix.lower()
+        matches = [n for n in names if n.lower().startswith(low)]
+        return sorted(matches, key=lambda n: (
+            not n.startswith(prefix),   # exact case prefix matches first
+            n.startswith('_'),          # underscore names last
+            len(n),                     # shorter (closer) names first
+            n.lower(),                  # alphabetical tiebreak
+        ))

--- a/nxt_editor/completion/hosts.py
+++ b/nxt_editor/completion/hosts.py
@@ -1,0 +1,180 @@
+"""Host environment providers: per-DCC convenience namespaces for completion.
+
+Each host declares the modules a user typically reaches for in that DCC so
+they autocomplete *before* the import is typed. Adding a module is one tuple;
+adding a DCC is one small subclass. A registry auto-detects the active host
+(honoring nxt's NXT_DCC env var first, then probing imports).
+
+The NxtRuntimeProvider mirrors the implicit globals nxt injects into a node
+compute (see nxt/stage.py setup_runtime_layer), so STAGE/self/nxt_path/...
+complete accurately regardless of host.
+"""
+import abc
+import importlib
+import importlib.util
+import os
+import types
+
+from nxt import nxt_path
+from nxt.constants import NXT_DCC_ENV_VAR
+from nxt.runtime import ExitNode, ExitGraph
+from nxt_editor.completion import logger
+
+
+def _can_import(module_path):
+    """True if a module is importable, without importing it (no side effects).
+    """
+    try:
+        return importlib.util.find_spec(module_path) is not None
+    except Exception:
+        return False
+
+
+def _live_namespace(module_specs):
+    """Import each (alias, module_path) spec, skipping any that fail.
+    :return: dict of alias -> live module object.
+    """
+    namespace = {}
+    for alias, module_path in module_specs:
+        try:
+            namespace[alias] = importlib.import_module(module_path)
+        except Exception:
+            logger.debug("Completion host: '{}' unavailable".format(module_path))
+    return namespace
+
+
+class NamespaceProvider(abc.ABC):
+    """Base for anything contributing names to the completion namespace."""
+
+    name = 'base'
+
+    @abc.abstractmethod
+    def namespaces(self):
+        """Return a dict of name -> live object for jedi.Interpreter."""
+        raise NotImplementedError
+
+
+class NxtRuntimeProvider(NamespaceProvider):
+    """The implicit globals every nxt compute runs with (host agnostic).
+
+    Importable runtime objects are exposed live so their attributes complete;
+    the dynamic ones (STAGE/self/w/execute) are None placeholders so at least
+    the names appear. The model overlays live values when a runtime exists.
+    """
+
+    name = 'nxt-runtime'
+
+    def namespaces(self):
+        return {'STAGE': None, 'self': None, 'w': None, 'execute': None,
+                'nxt_path': nxt_path, 'types': types,
+                'ExitNode': ExitNode, 'ExitGraph': ExitGraph}
+
+
+class HostProvider(NamespaceProvider):
+    """A DCC host contributing convenience modules. Subclass + declare modules.
+
+    ``name`` is the host identifier (also matched against the NXT_DCC env var)
+    and ``modules`` a tuple of (alias, 'module.path') exposed without an import.
+    """
+
+    name = 'base'
+    modules = ()
+
+    @classmethod
+    @abc.abstractmethod
+    def detect(cls):
+        """Return True if this host matches the running interpreter."""
+        raise NotImplementedError
+
+    def namespaces(self):
+        return _live_namespace(self.modules)
+
+
+class MayaHost(HostProvider):
+    name = 'maya'
+    modules = (
+        ('cmds', 'maya.cmds'),
+        ('mc', 'maya.cmds'),
+        ('mel', 'maya.mel'),
+        ('om', 'maya.api.OpenMaya'),
+        ('oma', 'maya.api.OpenMayaAnim'),
+        ('omui', 'maya.api.OpenMayaUI'),
+        ('omr', 'maya.api.OpenMayaRender'),
+        ('pm', 'pymel.core'),
+    )
+
+    @classmethod
+    def detect(cls):
+        return _can_import('maya.cmds')
+
+
+class MotionBuilderHost(HostProvider):
+    name = 'motionbuilder'
+    modules = (
+        ('pyfbsdk', 'pyfbsdk'),
+        ('pyfbsdk_additions', 'pyfbsdk_additions'),
+    )
+
+    @classmethod
+    def detect(cls):
+        return _can_import('pyfbsdk')
+
+
+class MaxHost(HostProvider):
+    name = '3dsmax'
+    modules = (
+        ('pymxs', 'pymxs'),
+    )
+
+    @classmethod
+    def detect(cls):
+        return _can_import('pymxs')
+
+
+class UnrealHost(HostProvider):
+    name = 'unreal'
+    modules = (
+        ('unreal', 'unreal'),
+    )
+
+    @classmethod
+    def detect(cls):
+        return _can_import('unreal')
+
+
+class StandaloneHost(HostProvider):
+    name = 'standalone'
+    modules = ()
+
+    @classmethod
+    def detect(cls):
+        return True
+
+
+# Registry of DCC hosts, highest priority first. Standalone is the fallback
+# and is handled explicitly by detect_host (never matched by probing).
+_HOST_CLASSES = (MayaHost, MotionBuilderHost, MaxHost, UnrealHost)
+
+
+def detect_host():
+    """Return an instance of the active host provider.
+
+    Resolution order:
+        1. The NXT_DCC env var, matched against each host's ``name``.
+        2. Probing each host's ``detect()``.
+        3. StandaloneHost as a guaranteed fallback.
+    :return: HostProvider
+    """
+    env_dcc = os.environ.get(NXT_DCC_ENV_VAR)
+    if env_dcc:
+        for host_cls in _HOST_CLASSES:
+            if host_cls.name == env_dcc:
+                return host_cls()
+    for host_cls in _HOST_CLASSES:
+        try:
+            if host_cls.detect():
+                logger.info("Completion host detected: {}".format(host_cls.name))
+                return host_cls()
+        except Exception:
+            logger.exception("Host detection failed for {}".format(host_cls.name))
+    return StandaloneHost()

--- a/nxt_editor/completion/model.py
+++ b/nxt_editor/completion/model.py
@@ -1,0 +1,125 @@
+"""CompletionModel: the Model of the completion MVC.
+
+Owns the optional jedi engine, builds the completion namespace from the host
++ runtime providers, and routes a CompletionContext to the right source. It
+is Qt free so it can be unit tested headlessly.
+"""
+from nxt_editor.completion import logger
+from nxt_editor.completion import hosts, sources
+from nxt_editor.completion.context import ContextKind
+
+# jedi is an optional dependency (pip install nxt-editor[completion]). Without
+# it completion falls back to keywords, builtins and buffer identifiers.
+try:
+    import jedi
+except ImportError:
+    jedi = None
+    logger.info('jedi not found, using basic code completion')
+else:
+    try:
+        # parso's on disk cache is written per interpreter and collides
+        # across DCC python versions (e.g. Maya 2024 py3.10 vs 2025 py3.11),
+        # raising on load. The in-memory cache still applies within a session.
+        import parso.cache as _parso_cache
+        _parso_cache._load_from_file_system = lambda *a, **k: None
+        _parso_cache._save_to_file_system = lambda *a, **k: None
+    except Exception:
+        logger.exception('Could not disable parso disk cache')
+    # Skip costly dynamic usage searches, we only need names.
+    jedi.settings.fast_parser = True
+    jedi.settings.dynamic_params = False
+    jedi.settings.dynamic_params_for_other_modules = False
+    jedi.settings.dynamic_array_additions = False
+    # Warm up once so the first real completion isn't cold.
+    try:
+        jedi.Interpreter('import os\nos.', namespaces=[{}]).complete(2, 3)
+    except Exception:
+        pass
+
+_HAS_JEDI = jedi is not None
+
+
+class CompletionModel(object):
+    """Aggregates namespace providers and completion sources.
+
+    :param host: A HostProvider; auto detected when omitted.
+    :param stage_model_getter: Callable returning the live stage model (used
+    for ${} tokens and live STAGE/self globals).
+    :param providers: Override the namespace providers (defaults to runtime
+    + host).
+    """
+
+    # Live globals pulled from the runtime layer's console (set after a run).
+    _LIVE_KEYS = ('STAGE', 'self', '__stage__', 'w', 'execute')
+
+    def __init__(self, host=None, stage_model_getter=None, providers=None):
+        self.host = host or hosts.detect_host()
+        self.providers = providers or [hosts.NxtRuntimeProvider(), self.host]
+        self._stage_model_getter = stage_model_getter
+        self.namespaces = self._build_namespaces()  # static base, built once
+        self.jedi_enabled = _HAS_JEDI
+        # Sources read the namespace through a getter so STAGE/self can
+        # reflect the live runtime each request.
+        self.jedi_source = (sources.JediSource(jedi, self._current_namespaces)
+                            if _HAS_JEDI else None)
+        # Runtime dir() for dynamic namespace modules (e.g. maya.cmds) and
+        # live STAGE/self attributes that jedi can only see statically.
+        self.runtime_attr_source = sources.RuntimeAttributeSource(
+            self._current_namespaces)
+        self.token_source = sources.TokenSource(stage_model_getter)
+        self.keyword_source = sources.KeywordSource()
+        self.document_source = sources.DocumentSource()
+
+    def _build_namespaces(self):
+        namespace = {}
+        for provider in self.providers:
+            try:
+                namespace.update(provider.namespaces())
+            except Exception:
+                logger.exception('Namespace provider {} failed'.format(
+                    getattr(provider, 'name', '?')))
+        return namespace
+
+    def _current_namespaces(self):
+        """Static base overlaid with live STAGE/self from the runtime layer."""
+        namespace = dict(self.namespaces)
+        namespace.update(self._live_namespace())
+        return namespace
+
+    def _live_namespace(self):
+        getter = self._stage_model_getter
+        model = getter() if getter else None
+        if model is None:
+            return {}
+        rt_layer = getattr(model, 'current_rt_layer', None)
+        console = getattr(rt_layer, '_console', None)
+        globals_dict = getattr(console, 'globals', None)
+        if not globals_dict:
+            return {}
+        live = {}
+        for key in self._LIVE_KEYS:
+            value = globals_dict.get(key)
+            if value is not None:
+                live[key] = value
+        return live
+
+    def candidates(self, context):
+        """Return the unfiltered candidate names for a context.
+        :param context: CompletionContext
+        :return: list of str
+        """
+        if context.is_token:
+            return self.token_source.candidates(context)
+        if context.kind is ContextKind.CODE:
+            names = self.runtime_attr_source.candidates(context)
+            if self.jedi_source is not None:
+                names += self.jedi_source.candidates(context)
+            else:
+                names += (self.keyword_source.candidates(context) +
+                          self.document_source.candidates(context))
+            names = sorted(set(names))
+            # Hide dunder noise unless the user is explicitly typing one.
+            if not context.prefix.startswith('_'):
+                names = [n for n in names if not n.startswith('__')]
+            return names
+        return []

--- a/nxt_editor/completion/popup.py
+++ b/nxt_editor/completion/popup.py
@@ -1,0 +1,84 @@
+"""CompletionPopup: the View of the completion MVC.
+
+A frameless, focus-less QListWidget parented to the editor viewport. Being a
+plain child widget (not a top level / ToolTip window) gives it reliable
+isVisible(), proper repaint on hide, and no focus stealing, so the editor
+keeps focus and drives navigation. It is display only: it emits ``accepted``
+when an item is chosen and holds no completion logic.
+"""
+from Qt import QtWidgets
+from Qt import QtCore
+
+_STYLE = ('QListWidget { background-color: #232323; color: #d8d8d8;'
+          ' border: 1px solid #555; outline: 0; }'
+          'QListWidget::item:selected { background-color: #4772b3;'
+          ' color: white; }')
+
+_MAX_ROWS = 10
+_MAX_ITEMS = 200
+
+
+class CompletionPopup(QtWidgets.QListWidget):
+    """List popup that displays candidates and reports the chosen one."""
+
+    accepted = QtCore.Signal(str)
+
+    def __init__(self, parent=None):
+        super(CompletionPopup, self).__init__(parent)
+        self.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.setUniformItemSizes(True)
+        self.setStyleSheet(_STYLE)
+        self.itemClicked.connect(self._on_item_clicked)
+        self.hide()
+
+    def _on_item_clicked(self, item):
+        self.accepted.emit(item.text())
+
+    def show_items(self, names, anchor_rect, viewport_height):
+        """Display ``names`` anchored under ``anchor_rect`` (the cursor rect).
+
+        :param names: Candidate strings (already filtered/sorted).
+        :param anchor_rect: QRect of the text cursor, in viewport coordinates.
+        :param viewport_height: Height of the parent viewport, for clamping.
+        """
+        self.clear()
+        self.addItems(list(names)[:_MAX_ITEMS])
+        self.setCurrentRow(0)
+        row_h = self.sizeHintForRow(0) if self.count() else 16
+        rows = min(self.count(), _MAX_ROWS)
+        metrics = self.fontMetrics()
+        text_w = max(metrics.horizontalAdvance(self.item(i).text())
+                     for i in range(self.count()))
+        self.setFixedWidth(min(text_w + 30, 400))
+        self.setFixedHeight(row_h * rows + 4)
+        # Anchor below the cursor; flip above if it would clip the bottom edge.
+        x = anchor_rect.left()
+        y = anchor_rect.bottom()
+        if y + self.height() > viewport_height:
+            y = max(0, anchor_rect.top() - self.height())
+        self.move(x, y)
+        self.show()
+        self.raise_()
+
+    def move_selection(self, key):
+        """Move the highlighted row for Up/Down/PageUp/PageDown."""
+        count = self.count()
+        if not count:
+            return
+        current = self.currentRow()
+        if key == QtCore.Qt.Key_Up:
+            row = (current - 1) % count
+        elif key == QtCore.Qt.Key_Down:
+            row = (current + 1) % count
+        elif key == QtCore.Qt.Key_PageUp:
+            row = max(0, current - _MAX_ROWS)
+        else:
+            row = min(count - 1, current + _MAX_ROWS)
+        self.setCurrentRow(row)
+
+    def current_text(self):
+        """Text of the highlighted item (falls back to the first row)."""
+        item = self.currentItem()
+        if item is None and self.count():
+            item = self.item(0)
+        return item.text() if item is not None else ''

--- a/nxt_editor/completion/sources.py
+++ b/nxt_editor/completion/sources.py
@@ -1,0 +1,158 @@
+"""Completion sources: each turns a CompletionContext into candidate names.
+
+Sources return *unfiltered* full name lists; the controller filters by the
+context prefix (jedi already filters, the static sources do not). This keeps
+the filtering rule in one place.
+"""
+import abc
+import builtins
+import keyword
+import re
+
+from nxt import nxt_path, tokens
+from nxt_editor.completion import logger
+from nxt_editor.completion.context import ContextKind
+
+_WORD_RE = re.compile(r'[A-Za-z_][A-Za-z0-9_]*')
+# A pure dotted attribute access left of the cursor, e.g. "cmds." or "a.b.c".
+_ATTR_EXPR_RE = re.compile(r'([A-Za-z_][A-Za-z0-9_.]*)\.\w*$')
+# nxt ${...} tokens are not valid Python, jedi can't parse a buffer with them.
+_TOKEN_RE = re.compile(r'\$\{[^{}]*\}')
+
+
+def sanitize_tokens(source):
+    """Replace ${...} tokens with equal-length string literals.
+
+    A single token makes jedi unable to parse the buffer (so nothing
+    completes). Replacing each with a same-length string keeps the code
+    parseable and preserves every line/column so the cursor position handed
+    to jedi stays correct.
+    :param source: str
+    :return: str
+    """
+    def _repl(match):
+        span = match.group(0)
+        return '"' + ('x' * (len(span) - 2)) + '"'
+    return _TOKEN_RE.sub(_repl, source)
+
+
+class CompletionSource(abc.ABC):
+    """Turns a CompletionContext into a list of candidate strings."""
+
+    @abc.abstractmethod
+    def candidates(self, context):
+        raise NotImplementedError
+
+
+class JediSource(CompletionSource):
+    """Rich Python completion via jedi.Interpreter against live namespaces.
+
+    ``namespace_getter`` is a callable returning the (possibly live)
+    namespace dict, so STAGE/self can reflect the current runtime each request.
+    """
+
+    def __init__(self, jedi_module, namespace_getter):
+        self._jedi = jedi_module
+        self._get_namespaces = namespace_getter
+
+    def candidates(self, context):
+        if context.kind is not ContextKind.CODE:
+            return []
+        source = sanitize_tokens(context.source)
+        try:
+            script = self._jedi.Interpreter(
+                source, namespaces=[self._get_namespaces()])
+            return [c.name for c in script.complete(context.line,
+                                                    context.column)]
+        except Exception:
+            logger.exception('Jedi completion failed')
+            return []
+
+
+class TokenSource(CompletionSource):
+    """nxt ${...} token completion: node paths and attribute names."""
+
+    def __init__(self, stage_model_getter=None):
+        self._get_model = stage_model_getter
+
+    def candidates(self, context):
+        model = self._get_model() if self._get_model else None
+        if model is None:
+            return []
+        if context.kind is ContextKind.TOKEN_ATTR:
+            node_path = context.token_body.rpartition('.')[0]
+            return sorted(set(model.get_node_attr_names(node_path) or []))
+        if context.kind is ContextKind.TOKEN_NODE:
+            names = []
+            try:
+                names += model.get_descendants(nxt_path.WORLD) or []
+            except Exception:
+                logger.exception('Failed to gather node paths for completion')
+            names += [t.prefix for t in tokens.TOKENTYPE.ALL if t.prefix]
+            return sorted(set(names))
+        return []
+
+
+class RuntimeAttributeSource(CompletionSource):
+    """dir() based attribute completion for live namespace objects.
+
+    jedi analyses modules statically, so dynamically populated modules such
+    as ``maya.cmds`` only expose their dunders. When the cursor is on an
+    attribute access of a name we injected into the namespace, fall back to
+    a runtime ``dir()`` of the real object. Expressions containing calls or
+    subscripts are skipped so nothing is ever executed.
+    """
+
+    def __init__(self, namespace_getter):
+        self._get_namespaces = namespace_getter
+
+    def candidates(self, context):
+        if context.kind is not ContextKind.CODE:
+            return []
+        lines = context.source.split('\n')
+        if not 0 <= context.line - 1 < len(lines):
+            return []
+        left = lines[context.line - 1][:context.column]
+        match = _ATTR_EXPR_RE.search(left)
+        if not match:
+            return []
+        parts = match.group(1).split('.')
+        namespaces = self._get_namespaces()
+        if parts[0] not in namespaces:
+            return []
+        obj = namespaces[parts[0]]
+        try:
+            for part in parts[1:]:
+                obj = getattr(obj, part)
+        except Exception:
+            return []
+        if obj is None:
+            return []
+        try:
+            return [n for n in dir(obj) if not n.startswith('__')]
+        except Exception:
+            return []
+
+
+class KeywordSource(CompletionSource):
+    """Python keywords + builtins; used only when jedi is unavailable."""
+
+    def __init__(self, extra=()):
+        builtin_names = [n for n in dir(builtins) if not n.startswith('__')]
+        self._names = sorted(set(keyword.kwlist + builtin_names + list(extra)))
+
+    def candidates(self, context):
+        if context.kind is not ContextKind.CODE:
+            return []
+        return self._names
+
+
+class DocumentSource(CompletionSource):
+    """Identifiers already present in the buffer; jedi-unavailable fallback."""
+
+    def candidates(self, context):
+        if context.kind is not ContextKind.CODE:
+            return []
+        words = set(_WORD_RE.findall(context.source))
+        words.discard(context.prefix)
+        return sorted(words)

--- a/nxt_editor/dockwidgets/code_editor.py
+++ b/nxt_editor/dockwidgets/code_editor.py
@@ -17,6 +17,8 @@ from nxt import DATA_STATE, nxt_path
 from nxt.nxt_node import INTERNAL_ATTRS
 from nxt_editor.dockwidgets import syntax
 from nxt_editor.constants import FONTS
+from nxt_editor.completion.model import CompletionModel
+from nxt_editor.completion.controller import CompletionController
 import nxt_editor
 
 logger = logging.getLogger(nxt_editor.LOGGER_NAME)
@@ -648,6 +650,13 @@ class NxtCodeEditor(QtWidgets.QPlainTextEdit):
         self.verticalScrollBar().valueChanged.connect(func)
         self.installEventFilter(self)
 
+        # Code completion (see nxt_editor.completion). The controller owns
+        # the popup and the model; it is driven from keyPressEvent and
+        # eventFilter. The stage model is read live for ${} tokens.
+        self._completion_active = False
+        self.completion = CompletionController(
+            self, CompletionModel(stage_model_getter=self._get_stage_model))
+
     def dragEnterEvent(self, event):
         if event.mimeData().hasFormat("text/plain"):
             event.acceptProposedAction()
@@ -772,6 +781,8 @@ class NxtCodeEditor(QtWidgets.QPlainTextEdit):
         super(NxtCodeEditor, self).focusInEvent(event)
 
     def focusOutEvent(self, event):
+        # Never leave the completion popup orphaned when focus leaves
+        self.completion.dismiss()
         for a, state in self.action_states.items():
             a.setEnabled(state)
         if self.standard_menu:
@@ -813,10 +824,22 @@ class NxtCodeEditor(QtWidgets.QPlainTextEdit):
 
         self.standard_menu.exec_(event.globalPos())
 
+    # Keys the completion popup claims away from the editor Tab/Enter actions
+    _POPUP_KEYS = (QtCore.Qt.Key_Enter, QtCore.Qt.Key_Return,
+                   QtCore.Qt.Key_Tab, QtCore.Qt.Key_Backtab,
+                   QtCore.Qt.Key_Escape, QtCore.Qt.Key_Up, QtCore.Qt.Key_Down,
+                   QtCore.Qt.Key_PageUp, QtCore.Qt.Key_PageDown)
+
     def eventFilter(self, widget, event):
         if not isinstance(event, QtCore.QEvent):
             return False
         if event.type() == QtCore.QEvent.Type.ShortcutOverride:
+            # While the popup is up, claim Tab/Enter/etc as normal key input
+            # so they reach keyPressEvent instead of indent_line/new_line
+            if (self.completion.popup_visible() and
+                    event.key() in self._POPUP_KEYS):
+                event.accept()
+                return True
             return True
         return False
 
@@ -1206,6 +1229,64 @@ class NxtCodeEditor(QtWidgets.QPlainTextEdit):
         self.ce_widget.stage_model.execute_snippet(code_string,
                                                    self.ce_widget.node_path,
                                                    globally=globally)
+
+    def _get_stage_model(self):
+        """Live stage model for the completion model (used by ${} tokens)."""
+        return self.ce_widget.stage_model
+
+    def insert_completion(self, text, prefix):
+        """Replace the active prefix with the chosen completion text.
+        :param text: completion string
+        :param prefix: the already typed prefix to replace
+        """
+        cursor = self.textCursor()
+        for _ in range(len(prefix)):
+            cursor.deletePreviousChar()
+        cursor.insertText(text)
+        self.setTextCursor(cursor)
+
+    def set_completion_active(self, active):
+        """Toggle the Tab/Enter edit actions while the popup is up so the
+        completion can claim those keys. Guarded so we never re-enable
+        actions the lock state disabled.
+        :param active: bool
+        """
+        if active == self._completion_active:
+            return
+        self._completion_active = active
+        for name in ('indent_line', 'unindent_line', 'new_line'):
+            action = getattr(self.ce_actions, name, None)
+            if action is not None:
+                action.setEnabled(not active)
+
+    def keyPressEvent(self, event):
+        """Delegate completion popup keys, else handle normal text input and
+        ask for completions. Ctrl+Space requests completion explicitly.
+        """
+        if self.completion.handle_key_press(event):
+            event.accept()
+            return
+        ctrl = event.modifiers() & QtCore.Qt.ControlModifier
+        manual = bool(ctrl) and event.key() == QtCore.Qt.Key_Space
+        if not manual:
+            super(NxtCodeEditor, self).keyPressEvent(event)
+        if self.isReadOnly():
+            return
+        if not manual:
+            # Don't pop on modifier only keys or ctrl/alt chords
+            if event.modifiers() & (QtCore.Qt.ControlModifier |
+                                    QtCore.Qt.AltModifier):
+                self.completion.dismiss()
+                return
+            if event.key() in (QtCore.Qt.Key_Shift, QtCore.Qt.Key_Control,
+                               QtCore.Qt.Key_Alt, QtCore.Qt.Key_Meta):
+                return
+        self.completion.request(force=manual)
+
+    def mousePressEvent(self, event):
+        # Clicking in the editor dismisses the completion popup
+        self.completion.dismiss()
+        super(NxtCodeEditor, self).mousePressEvent(event)
 
 
 class NumberBar(QtWidgets.QWidget):

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ setuptools.setup(
                       'qt.py<3',
                       'PySide6>=6,<6.8'
                       ],
+    extras_require={
+        # Rich code completion in the code editor (optional)
+        'completion': ['jedi>=0.19'],
+    },
     package_data={
         # covers text nxt files
         "": ["*.nxt"],


### PR DESCRIPTION
Adds a completion popup to the code editor, as a small MVC package `nxt_editor.completion`:

- **Python code**: via [jedi](https://github.com/davidhalter/jedi) when installed (new extra: `pip install nxt-editor[completion]`). Without jedi it falls back to keywords, builtins and identifiers already in the buffer, so nothing changes for existing installs.
- **nxt runtime globals**: `STAGE`, `self`, `nxt_path`, `ExitNode`, `ExitGraph`… complete as they do inside a compute, and live `STAGE`/`self` are picked up from the runtime layer console after a run.
- **Host modules**: `cmds`, `mel`, `om`, `pm` (Maya), `pyfbsdk` (MotionBuilder), `pymxs` (3ds Max), `unreal` complete before the import is typed. Host is detected from `NXT_DCC` or by probing imports; adding a DCC is one small subclass in `hosts.py`. Dynamically populated modules like `maya.cmds` use a runtime `dir()` since jedi only sees them statically.
- **${} tokens**: node paths and attribute names from the stage model, plus the `file::` / `path::` / `contents::` prefixes.

Behaviour: pops while typing (debounced for the jedi path), `Ctrl+Space` forces it, `Tab`/`Enter` accept, `Esc` dismisses, arrows navigate. The popup is a plain child of the viewport so it never steals focus. Tab/Enter are only claimed while the popup is visible; the indent / new line actions are untouched otherwise.

Tokens are replaced by same-length string literals before handing the buffer to jedi so line/column positions stay valid. parso's on-disk cache is disabled because it collides across DCC python versions.